### PR TITLE
[codex] Add project delivery plan

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+Describe the phase or change that was closed in this PR.
+
+## Why
+
+Explain why this phase was needed and what user-visible or engineering risk it addresses.
+
+## Changes
+
+- List the concrete implementation changes.
+
+## Verification
+
+- List the exact commands or checks run.
+
+## Project Status Update
+
+- Current stage after merge:
+- Closed checklist items:
+- Remaining open issues:

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,0 +1,127 @@
+# Project Plan
+
+## Objective
+
+Build a local autonomous AI agent that uses the ChatGPT web UI through Playwright as the reasoning engine, executes local tools safely, preserves memory, and recovers from selector and formatting failures.
+
+## Delivery Rules
+
+Every closed phase must go through the same workflow:
+
+1. Update `docs/PROJECT_STATUS.md`.
+2. Mark completed checklist items in this plan.
+3. Run verification for the phase.
+4. Commit the phase delta.
+5. Push the branch.
+6. Open a pull request.
+7. Merge the pull request.
+8. Update the current stage and completed items again if merge changed the state.
+
+## Phases
+
+### Phase 1. Repository Foundation
+
+Goal:
+- Bootstrap the repository, TypeScript toolchain, build output, and runtime entrypoint.
+
+Done when:
+- `package.json`, `tsconfig.json`, and CLI entrypoints exist.
+- Build and typecheck pass locally.
+- The repository has a reproducible launch path.
+
+Checklist:
+- [x] Initialize Node.js + TypeScript project.
+- [x] Add build and typecheck scripts.
+- [x] Add runnable entrypoints.
+- [x] Add local launch shell script.
+
+### Phase 2. Core Agent Runtime
+
+Goal:
+- Implement the strict agent loop, planning, parsing, guardrails, memory, and tool dispatch.
+
+Done when:
+- The project can generate a plan, execute tool calls, and stop on `FINAL`.
+- Invalid tool payloads and repeated loops are blocked.
+
+Checklist:
+- [x] Add protocol types and prompt builders.
+- [x] Add strict parser and planner parser.
+- [x] Add guard rules for tool inputs and shell commands.
+- [x] Add memory persistence.
+- [x] Add tool dispatch layer.
+- [x] Add main agent loop.
+
+### Phase 3. ChatGPT Bridge Hardening
+
+Goal:
+- Make ChatGPT web interaction stable across streaming output and DOM drift.
+
+Done when:
+- The bridge restores sessions reliably.
+- The composer can be found with resilient locators.
+- Streaming responses are stabilized before parsing.
+- Selector failures can fall back to self-healing.
+
+Checklist:
+- [x] Add Playwright ChatGPT bridge.
+- [x] Add response stabilizer.
+- [x] Add selector cache and fallback strategy.
+- [x] Add self-heal ranking logic.
+- [ ] Validate the composer locator against the live ChatGPT UI after login.
+- [ ] Capture and fix any live selector regressions discovered during smoke tests.
+
+### Phase 4. Tooling and Sandbox Validation
+
+Goal:
+- Verify filesystem, shell, and browser tools behave safely and inside project limits.
+
+Done when:
+- Filesystem access is restricted to `agent/workspace`.
+- Shell commands are sanitized.
+- Browser tools can navigate, click, and type using recovery logic.
+
+Checklist:
+- [x] Add workspace sandbox.
+- [x] Add restricted shell runner.
+- [x] Add browser tool wrapper.
+- [ ] Smoke-test each tool path against the live loop.
+
+### Phase 5. Delivery Workflow
+
+Goal:
+- Make phase closure explicit and repeatable in-repo.
+
+Done when:
+- The project contains a written phase plan.
+- The project contains a live status board.
+- The repo contains a repeatable phase-close GitHub workflow.
+
+Checklist:
+- [x] Add project plan.
+- [x] Add project status tracker.
+- [x] Add PR template.
+- [x] Add phase-close helper script.
+
+### Phase 6. End-to-End Acceptance
+
+Goal:
+- Validate the user-facing acceptance criteria against real tasks.
+
+Done when:
+- The agent can read and write files.
+- The agent can execute allowed shell commands.
+- The agent can browse pages.
+- The agent can plan and execute multi-step tasks.
+- The agent can recover from selector drift and formatting errors.
+
+Checklist:
+- [ ] Run a file task end-to-end.
+- [ ] Run a shell task end-to-end.
+- [ ] Run a browser task end-to-end.
+- [ ] Run a multi-step planning task end-to-end.
+- [ ] Document remaining defects and follow-up phases if needed.
+
+## Current Exit Criteria
+
+The project is not complete until Phases 3, 4, and 6 are closed with live validation, not only static implementation.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,0 +1,46 @@
+# Project Status
+
+## Current Stage
+
+- Active stage: `Phase 3. ChatGPT Bridge Hardening`
+- Overall state: `In Progress`
+- Last updated: `2026-03-19`
+
+## Closed Phases
+
+- `Phase 1. Repository Foundation`
+- `Phase 2. Core Agent Runtime`
+- `Phase 5. Delivery Workflow`
+
+## In-Progress Phases
+
+- `Phase 3. ChatGPT Bridge Hardening`
+- `Phase 4. Tooling and Sandbox Validation`
+
+## Pending Phases
+
+- `Phase 6. End-to-End Acceptance`
+
+## Completed Items
+
+- Base repository, TypeScript config, and local run script are in place.
+- Core loop, planner, parser, protocol, guard, memory, and tool dispatch are implemented.
+- ChatGPT bridge, stabilizer, selector fallback, and self-heal modules are implemented.
+- Project planning and phase-close workflow are now tracked in-repo.
+
+## Open Issues
+
+- Live ChatGPT smoke run still fails on composer resolution after login.
+- End-to-end validation is incomplete until the live bridge issue is fixed.
+
+## Phase Close Checklist
+
+Use this checklist every time a phase is closed:
+
+1. Update this file and `docs/PROJECT_PLAN.md`.
+2. Run the relevant checks.
+3. Commit the phase changes on a branch.
+4. Push to GitHub.
+5. Open a PR.
+6. Merge the PR.
+7. Confirm the merged default branch reflects the updated stage.

--- a/scripts/close-phase.sh
+++ b/scripts/close-phase.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 2 ]; then
+  echo 'Usage: ./scripts/close-phase.sh "<phase-slug>" "<commit-message>" [--merge]'
+  exit 1
+fi
+
+PHASE_SLUG=$1
+COMMIT_MESSAGE=$2
+MERGE_NOW=${3:-}
+
+BRANCH=$(git branch --show-current)
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  BRANCH="codex/$PHASE_SLUG"
+  git checkout -b "$BRANCH"
+fi
+
+npm run typecheck
+git add -A
+
+if ! git diff --cached --quiet; then
+  git commit -m "$COMMIT_MESSAGE"
+fi
+
+git push -u origin "$BRANCH"
+
+if gh pr view "$BRANCH" >/dev/null 2>&1; then
+  PR_URL=$(gh pr view "$BRANCH" --json url --jq '.url')
+else
+  PR_URL=$(GH_PROMPT_DISABLED=1 GIT_TERMINAL_PROMPT=0 gh pr create --fill --head "$BRANCH")
+fi
+
+echo "PR: $PR_URL"
+
+if [ "$MERGE_NOW" = "--merge" ]; then
+  gh pr merge "$BRANCH" --squash --delete-branch
+fi


### PR DESCRIPTION
This PR closes the delivery-workflow documentation phase for the local ChatGPT agent project.

The repository already contained the initial implementation, but it did not yet have an explicit in-repo project plan, a live stage tracker, a pull request template, or a repeatable phase-close workflow. That meant future phases could be implemented without a stable definition of done or a consistent commit/push/PR/merge routine.

This change adds a structured project plan with concrete phases and checklists, a project status document that records the current stage and open issues, a PR template that forces project-status updates to be captured in each merge, and a `scripts/close-phase.sh` helper that standardizes the GitHub flow for phase closure.

Verification used for this phase was `npm run typecheck`.
