### PR TITLE
[codex] Harden ChatGPT bridge auth handling

### DIFF
--- a/agent/bridge/chatgpt.ts
+++ b/agent/bridge/chatgpt.ts
@@ -48,6 +48,7 @@ export class ChatGPTBridge {
     this.context = await this.browser.newContext(storageState ? { storageState } : {});
     this.page = await this.context.newPage();
     await this.page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
+    await this.waitForChatGPTSurface();
     await clickNewChatIfAvailable(this.page, this.selectorCache);
 
     if (!storageState) {
@@ -58,6 +59,7 @@ export class ChatGPTBridge {
   async resetConversation(): Promise<void> {
     const page = await this.getPage();
     await page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
+    await this.waitForChatGPTSurface();
     await clickNewChatIfAvailable(page, this.selectorCache);
     this.primed = false;
   }
@@ -96,6 +98,7 @@ export class ChatGPTBridge {
 
   private async sendPrompt(prompt: string): Promise<string> {
     const page = await this.getPage();
+    await this.ensureReadyForPrompt();
     const composer = await withRetry(
       async () => resolveComposer(page, this.selectorCache),
       { retries: limits.maxRetries, initialDelayMs: 500 }
@@ -104,7 +107,11 @@ export class ChatGPTBridge {
     const previousAssistantText = await this.extractLatestAssistantText();
 
     await composer.click({ timeout: limits.selectorTimeoutMs });
-    await composer.fill(prompt, { timeout: limits.selectorTimeoutMs });
+    await composer.fill(prompt, { timeout: limits.selectorTimeoutMs }).catch(async () => {
+      await composer.press("Control+A").catch(() => undefined);
+      await composer.press("Meta+A").catch(() => undefined);
+      await composer.type(prompt, { timeout: limits.selectorTimeoutMs });
+    });
     await composer.press("Enter");
 
     return waitForStableText(() => this.extractLatestAssistantText(), {
@@ -161,11 +168,12 @@ export class ChatGPTBridge {
       );
     }
 
-    const page = await this.getPage();
-    console.log("No ChatGPT storage state found. Log in in the opened browser window. Waiting for the message box...");
+    console.log(
+      "No ChatGPT storage state found. Log in in the opened browser window. Waiting for an authenticated ChatGPT page..."
+    );
     await withRetry(
       async () => {
-        await resolveComposer(page, this.selectorCache);
+        await this.waitForAuthenticatedPromptReadiness();
       },
       {
         retries: Math.ceil(limits.loginWaitTimeoutMs / 5_000),
@@ -185,6 +193,42 @@ export class ChatGPTBridge {
       return undefined;
     }
   }
+
+  private async waitForChatGPTSurface(): Promise<void> {
+    const page = await this.getPage();
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForURL(/chatgpt\.com|chat\.openai\.com|auth\.openai\.com|accounts\.google\.com/, {
+      timeout: limits.toolPageTimeoutMs
+    });
+  }
+
+  private async ensureReadyForPrompt(): Promise<void> {
+    const page = await this.getPage();
+    await this.waitForChatGPTSurface();
+
+    if (await isExternalAuthPage(page)) {
+      throw new Error("ChatGPT is currently on an external authentication page. Complete login and return to ChatGPT.");
+    }
+
+    if (await isLoggedOutHomepage(page)) {
+      throw new Error("ChatGPT is showing the logged-out homepage. Complete login to reuse a real session.");
+    }
+  }
+
+  private async waitForAuthenticatedPromptReadiness(): Promise<void> {
+    const page = await this.getPage();
+    await this.waitForChatGPTSurface();
+
+    if (await isExternalAuthPage(page)) {
+      throw new Error("Still waiting for ChatGPT to return from the external authentication page.");
+    }
+
+    if (await isLoggedOutHomepage(page)) {
+      throw new Error("Still on the logged-out ChatGPT homepage.");
+    }
+
+    await resolveComposer(page, this.selectorCache);
+  }
 }
 
 function parseBoolean(value: string | undefined, fallback: boolean): boolean {
@@ -193,4 +237,25 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   }
 
   return value.toLowerCase() === "true";
+}
+
+async function isExternalAuthPage(page: Page): Promise<boolean> {
+  const url = page.url();
+  return /accounts\.google\.com|auth\.openai\.com/.test(url);
+}
+
+async function isLoggedOutHomepage(page: Page): Promise<boolean> {
+  if (await isExternalAuthPage(page)) {
+    return false;
+  }
+
+  const loginCount =
+    (await page.getByRole("button", { name: /log in|sign in|увійти/i }).count()) +
+    (await page.getByRole("link", { name: /log in|sign in|увійти/i }).count());
+
+  const signupCount =
+    (await page.getByRole("button", { name: /sign up|зареєструватися/i }).count()) +
+    (await page.getByRole("link", { name: /sign up|зареєструватися/i }).count());
+
+  return loginCount > 0 && signupCount > 0;
 }

--- a/agent/bridge/selectors.ts
+++ b/agent/bridge/selectors.ts
@@ -4,7 +4,13 @@ import { limits } from "../config/limits.ts";
 import { healSelector } from "../resilience/self-heal.ts";
 
 type CachedKey = "composer" | "new-chat";
-type StrategyName = "role-textbox" | "placeholder-message" | "textarea" | "heal";
+type StrategyName =
+  | "role-textbox"
+  | "placeholder-message"
+  | "contenteditable-role"
+  | "contenteditable"
+  | "textarea"
+  | "heal";
 
 type SelectorCache = Map<CachedKey, StrategyName>;
 
@@ -14,8 +20,24 @@ export function createSelectorCache(): SelectorCache {
 
 async function isUsable(locator: Locator): Promise<boolean> {
   try {
-    await locator.waitFor({ state: "visible", timeout: 1_000 });
-    return await locator.isEnabled();
+    const candidate = locator.first();
+    await candidate.waitFor({ state: "visible", timeout: 1_000 });
+    return await candidate.evaluate((element) => {
+      if (!(element instanceof HTMLElement)) {
+        return false;
+      }
+
+      if (element.getAttribute("aria-disabled") === "true") {
+        return false;
+      }
+
+      if ("disabled" in element && typeof element.disabled === "boolean" && element.disabled) {
+        return false;
+      }
+
+      const style = window.getComputedStyle(element);
+      return style.visibility !== "hidden" && style.display !== "none";
+    });
   } catch {
     return false;
   }
@@ -78,14 +100,18 @@ function buildComposerStrategies(page: Page): Record<StrategyName, () => Promise
   return {
     "role-textbox": async () =>
       pickFirstUsable([
-        page.getByRole("textbox", { name: /message|ask|chat/i }).last(),
+        page.getByRole("textbox", { name: /message|ask|chat|anything/i }).last(),
         page.getByRole("textbox").last()
       ]),
     "placeholder-message": async () =>
       pickFirstUsable([
-        page.getByPlaceholder(/message/i).last(),
-        page.getByPlaceholder(/send a message/i).last()
+        page.getByPlaceholder(/message|anything/i).last(),
+        page.getByPlaceholder(/send a message|ask anything/i).last()
       ]),
+    "contenteditable-role": async () =>
+      pickFirstUsable([page.locator('[role="textbox"][contenteditable="true"]').last()]),
+    contenteditable: async () =>
+      pickFirstUsable([page.locator('[contenteditable="true"]').last()]),
     textarea: async () => pickFirstUsable([page.locator("textarea").last()]),
     heal: async () => {
       const healed = await healSelector(page, "message chat input");
@@ -99,7 +125,7 @@ function buildComposerStrategies(page: Page): Record<StrategyName, () => Promise
         case "role":
           return page.getByRole(healed.role as Parameters<Page["getByRole"]>[0], {
             name: healed.name
-          });
+          }).first();
         case "text":
           return page.getByText(healed.value).last();
         default:

--- a/dist/agent/bridge/chatgpt.js
+++ b/dist/agent/bridge/chatgpt.js
@@ -33,6 +33,7 @@ export class ChatGPTBridge {
         this.context = await this.browser.newContext(storageState ? { storageState } : {});
         this.page = await this.context.newPage();
         await this.page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
+        await this.waitForChatGPTSurface();
         await clickNewChatIfAvailable(this.page, this.selectorCache);
         if (!storageState) {
             await this.captureStorageStateAfterManualLogin();
@@ -41,6 +42,7 @@ export class ChatGPTBridge {
     async resetConversation() {
         const page = await this.getPage();
         await page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
+        await this.waitForChatGPTSurface();
         await clickNewChatIfAvailable(page, this.selectorCache);
         this.primed = false;
     }
@@ -72,10 +74,15 @@ export class ChatGPTBridge {
     }
     async sendPrompt(prompt) {
         const page = await this.getPage();
+        await this.ensureReadyForPrompt();
         const composer = await withRetry(async () => resolveComposer(page, this.selectorCache), { retries: limits.maxRetries, initialDelayMs: 500 });
         const previousAssistantText = await this.extractLatestAssistantText();
         await composer.click({ timeout: limits.selectorTimeoutMs });
-        await composer.fill(prompt, { timeout: limits.selectorTimeoutMs });
+        await composer.fill(prompt, { timeout: limits.selectorTimeoutMs }).catch(async () => {
+            await composer.press("Control+A").catch(() => undefined);
+            await composer.press("Meta+A").catch(() => undefined);
+            await composer.type(prompt, { timeout: limits.selectorTimeoutMs });
+        });
         await composer.press("Enter");
         return waitForStableText(() => this.extractLatestAssistantText(), {
             mustDifferFrom: previousAssistantText
@@ -116,10 +123,9 @@ export class ChatGPTBridge {
         if (this.options.headless) {
             throw new Error(`Storage state not found at ${this.options.storageStatePath}. Run once with CHATGPT_HEADLESS=false to log in.`);
         }
-        const page = await this.getPage();
-        console.log("No ChatGPT storage state found. Log in in the opened browser window. Waiting for the message box...");
+        console.log("No ChatGPT storage state found. Log in in the opened browser window. Waiting for an authenticated ChatGPT page...");
         await withRetry(async () => {
-            await resolveComposer(page, this.selectorCache);
+            await this.waitForAuthenticatedPromptReadiness();
         }, {
             retries: Math.ceil(limits.loginWaitTimeoutMs / 5_000),
             initialDelayMs: 5_000
@@ -136,10 +142,52 @@ export class ChatGPTBridge {
             return undefined;
         }
     }
+    async waitForChatGPTSurface() {
+        const page = await this.getPage();
+        await page.waitForLoadState("domcontentloaded");
+        await page.waitForURL(/chatgpt\.com|chat\.openai\.com|auth\.openai\.com|accounts\.google\.com/, {
+            timeout: limits.toolPageTimeoutMs
+        });
+    }
+    async ensureReadyForPrompt() {
+        const page = await this.getPage();
+        await this.waitForChatGPTSurface();
+        if (await isExternalAuthPage(page)) {
+            throw new Error("ChatGPT is currently on an external authentication page. Complete login and return to ChatGPT.");
+        }
+        if (await isLoggedOutHomepage(page)) {
+            throw new Error("ChatGPT is showing the logged-out homepage. Complete login to reuse a real session.");
+        }
+    }
+    async waitForAuthenticatedPromptReadiness() {
+        const page = await this.getPage();
+        await this.waitForChatGPTSurface();
+        if (await isExternalAuthPage(page)) {
+            throw new Error("Still waiting for ChatGPT to return from the external authentication page.");
+        }
+        if (await isLoggedOutHomepage(page)) {
+            throw new Error("Still on the logged-out ChatGPT homepage.");
+        }
+        await resolveComposer(page, this.selectorCache);
+    }
 }
 function parseBoolean(value, fallback) {
     if (value === undefined) {
         return fallback;
     }
     return value.toLowerCase() === "true";
+}
+async function isExternalAuthPage(page) {
+    const url = page.url();
+    return /accounts\.google\.com|auth\.openai\.com/.test(url);
+}
+async function isLoggedOutHomepage(page) {
+    if (await isExternalAuthPage(page)) {
+        return false;
+    }
+    const loginCount = (await page.getByRole("button", { name: /log in|sign in|увійти/i }).count()) +
+        (await page.getByRole("link", { name: /log in|sign in|увійти/i }).count());
+    const signupCount = (await page.getByRole("button", { name: /sign up|зареєструватися/i }).count()) +
+        (await page.getByRole("link", { name: /sign up|зареєструватися/i }).count());
+    return loginCount > 0 && signupCount > 0;
 }

--- a/dist/agent/bridge/selectors.js
+++ b/dist/agent/bridge/selectors.js
@@ -5,8 +5,21 @@ export function createSelectorCache() {
 }
 async function isUsable(locator) {
     try {
-        await locator.waitFor({ state: "visible", timeout: 1_000 });
-        return await locator.isEnabled();
+        const candidate = locator.first();
+        await candidate.waitFor({ state: "visible", timeout: 1_000 });
+        return await candidate.evaluate((element) => {
+            if (!(element instanceof HTMLElement)) {
+                return false;
+            }
+            if (element.getAttribute("aria-disabled") === "true") {
+                return false;
+            }
+            if ("disabled" in element && typeof element.disabled === "boolean" && element.disabled) {
+                return false;
+            }
+            const style = window.getComputedStyle(element);
+            return style.visibility !== "hidden" && style.display !== "none";
+        });
     }
     catch {
         return false;
@@ -55,13 +68,15 @@ export async function clickNewChatIfAvailable(page, cache) {
 function buildComposerStrategies(page) {
     return {
         "role-textbox": async () => pickFirstUsable([
-            page.getByRole("textbox", { name: /message|ask|chat/i }).last(),
+            page.getByRole("textbox", { name: /message|ask|chat|anything/i }).last(),
             page.getByRole("textbox").last()
         ]),
         "placeholder-message": async () => pickFirstUsable([
-            page.getByPlaceholder(/message/i).last(),
-            page.getByPlaceholder(/send a message/i).last()
+            page.getByPlaceholder(/message|anything/i).last(),
+            page.getByPlaceholder(/send a message|ask anything/i).last()
         ]),
+        "contenteditable-role": async () => pickFirstUsable([page.locator('[role="textbox"][contenteditable="true"]').last()]),
+        contenteditable: async () => pickFirstUsable([page.locator('[contenteditable="true"]').last()]),
         textarea: async () => pickFirstUsable([page.locator("textarea").last()]),
         heal: async () => {
             const healed = await healSelector(page, "message chat input");
@@ -74,7 +89,7 @@ function buildComposerStrategies(page) {
                 case "role":
                     return page.getByRole(healed.role, {
                         name: healed.name
-                    });
+                    }).first();
                 case "text":
                     return page.getByText(healed.value).last();
                 default:

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -68,8 +68,8 @@ Checklist:
 - [x] Add response stabilizer.
 - [x] Add selector cache and fallback strategy.
 - [x] Add self-heal ranking logic.
+- [x] Capture and fix live selector/auth regressions discovered during smoke tests.
 - [ ] Validate the composer locator against the live ChatGPT UI after login.
-- [ ] Capture and fix any live selector regressions discovered during smoke tests.
 
 ### Phase 4. Tooling and Sandbox Validation
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -27,11 +27,13 @@
 - Core loop, planner, parser, protocol, guard, memory, and tool dispatch are implemented.
 - ChatGPT bridge, stabilizer, selector fallback, and self-heal modules are implemented.
 - Project planning and phase-close workflow are now tracked in-repo.
+- The bridge now distinguishes logged-out/public ChatGPT surfaces from an authenticated reusable session.
+- The bridge now handles `contenteditable` textbox variants more safely.
 
 ## Open Issues
 
-- Live ChatGPT smoke run still fails on composer resolution after login.
-- End-to-end validation is incomplete until the live bridge issue is fixed.
+- Authenticated live smoke validation is still required after a real ChatGPT login.
+- End-to-end validation is incomplete until the authenticated bridge path is confirmed.
 
 ## Phase Close Checklist
 


### PR DESCRIPTION
This PR hardens the ChatGPT web bridge after the first live smoke run exposed a real selector/auth problem.

The prior implementation treated any visible ChatGPT textbox as proof that the agent was ready to operate. That was incorrect because the public logged-out ChatGPT homepage also exposes a textbox. In practice, that let the bridge save an unauthenticated storage state and later fail in inconsistent ways when the flow moved into or out of external authentication pages.

This change makes the bridge auth-aware. It now distinguishes the logged-out homepage from a reusable authenticated session, detects when the browser is still on an external authentication surface, broadens the composer locator strategy to include modern `contenteditable` variants, and loosens interactability checks so they work better with non-input textbox implementations. The project plan and status documents were also updated to reflect that the regression is fixed, while the authenticated live smoke test remains the last open item before Phase 3 can be closed.

Verification for this PR:
- `npm run typecheck`
- `npm run build`
- live inspection of the current ChatGPT public UI via Playwright snapshot
- headless smoke run confirming the bridge now fails fast on missing authenticated storage state instead of silently accepting a logged-out surface
