### PR TITLE
[codex] Plan menu bar app and harden task proofing

### DIFF
--- a/agent/bridge/chatgpt-extension.ts
+++ b/agent/bridge/chatgpt-extension.ts
@@ -1,12 +1,14 @@
 import { LocalBridgeServer } from "./local-bridge-server.ts";
-import type { ReasoningBridge } from "./types.ts";
+import type { ReasoningBridge, ReasoningBridgeOptions } from "./types.ts";
 
 export class ExtensionChatGPTBridge implements ReasoningBridge {
   server: LocalBridgeServer;
   primed = false;
+  projectName: string | null;
 
-  constructor(server = new LocalBridgeServer()) {
+  constructor(options: ReasoningBridgeOptions = {}, server = new LocalBridgeServer()) {
     this.server = server;
+    this.projectName = options.projectName?.trim() || process.env.CHATGPT_PROJECT_NAME?.trim() || null;
   }
 
   async initialize(): Promise<void> {
@@ -24,7 +26,7 @@ export class ExtensionChatGPTBridge implements ReasoningBridge {
 
   async resetConversation(): Promise<void> {
     await this.initialize();
-    const result = await this.server.sendCommand("reset_conversation", {});
+    const result = await this.server.sendCommand("reset_conversation", this.getProjectPayload());
     if (!result.ok) {
       throw new Error(result.error ?? "Extension failed to reset the ChatGPT conversation.");
     }
@@ -41,7 +43,10 @@ export class ExtensionChatGPTBridge implements ReasoningBridge {
 
   async ask(prompt: string): Promise<string> {
     await this.initialize();
-    const result = await this.server.sendCommand("send_prompt", { prompt });
+    const result = await this.server.sendCommand("send_prompt", {
+      prompt,
+      ...this.getProjectPayload()
+    });
     if (!result.ok) {
       throw new Error(result.error ?? "Extension failed to send the prompt to ChatGPT.");
     }
@@ -57,5 +62,9 @@ export class ExtensionChatGPTBridge implements ReasoningBridge {
   async close(): Promise<void> {
     await this.server.close();
     this.primed = false;
+  }
+
+  private getProjectPayload(): Record<string, unknown> {
+    return this.projectName ? { projectName: this.projectName } : {};
   }
 }

--- a/agent/bridge/chatgpt.ts
+++ b/agent/bridge/chatgpt.ts
@@ -17,6 +17,7 @@ type BridgeOptions = {
   userDataDir: string;
   executablePath?: string;
   cdpUrl?: string;
+  projectName?: string;
 };
 
 export class ChatGPTBridge {
@@ -41,7 +42,8 @@ export class ChatGPTBridge {
       executablePath: resolveChromeExecutable(
         process.env.CHATGPT_BROWSER_EXECUTABLE_PATH ?? undefined
       ),
-      cdpUrl: process.env.CHATGPT_CDP_URL ?? undefined
+      cdpUrl: process.env.CHATGPT_CDP_URL ?? undefined,
+      projectName: options.projectName?.trim() || process.env.CHATGPT_PROJECT_NAME?.trim() || undefined
     };
   }
 
@@ -60,6 +62,7 @@ export class ChatGPTBridge {
     this.page = this.context.pages()[0] ?? (await this.context.newPage());
     await this.page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
     await this.waitForChatGPTSurface();
+    await this.ensureProjectSelected();
     await clickNewChatIfAvailable(this.page, this.selectorCache);
 
     if (!storageState) {
@@ -92,6 +95,7 @@ export class ChatGPTBridge {
     const page = await this.getPage();
     await page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
     await this.waitForChatGPTSurface();
+    await this.ensureProjectSelected();
     await clickNewChatIfAvailable(page, this.selectorCache);
     this.primed = false;
   }
@@ -139,6 +143,7 @@ export class ChatGPTBridge {
   private async sendPrompt(prompt: string): Promise<string> {
     const page = await this.getPage();
     await this.ensureReadyForPrompt();
+    await this.ensureProjectSelected();
     const composer = await withRetry(
       async () => resolveComposer(page, this.selectorCache),
       { retries: limits.maxRetries, initialDelayMs: 500 }
@@ -255,6 +260,98 @@ export class ChatGPTBridge {
     }
   }
 
+  private async ensureProjectSelected(): Promise<void> {
+    const projectName = this.options.projectName?.trim();
+    if (!projectName) {
+      return;
+    }
+
+    const page = await this.getPage();
+    const alreadySelected = await page.evaluate((targetName) => {
+      const normalizedTarget = normalizeComparableText(targetName);
+      const candidates = Array.from(
+        document.querySelectorAll("main h1, main h2, nav a, nav button, aside a, aside button")
+      ) as HTMLElement[];
+
+      return candidates.some((element) => {
+        if (!isDomElementVisible(element)) {
+          return false;
+        }
+
+        const text = normalizeComparableText(
+          [element.textContent ?? "", element.getAttribute("aria-label") ?? ""].join(" ")
+        );
+        return text === normalizedTarget && element.getAttribute("aria-current") === "page";
+      });
+
+      function normalizeComparableText(value: string): string {
+        return value.replace(/\s+/g, " ").trim().toLowerCase();
+      }
+
+      function isDomElementVisible(element: HTMLElement): boolean {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+      }
+    }, projectName);
+
+    if (alreadySelected) {
+      return;
+    }
+
+    await expandProjectsSectionIfPresent(page);
+
+    const clicked = await page.evaluate((targetName) => {
+      const normalizedTarget = normalizeComparableText(targetName);
+      const candidates = Array.from(document.querySelectorAll("a,button,[role='button']")) as HTMLElement[];
+
+      const match = candidates.find((element) => {
+        if (!isDomElementVisible(element)) {
+          return false;
+        }
+
+        const text = normalizeComparableText(
+          [
+            element.textContent ?? "",
+            element.getAttribute("aria-label") ?? "",
+            element.getAttribute("title") ?? ""
+          ].join(" ")
+        );
+
+        if (text !== normalizedTarget) {
+          return false;
+        }
+
+        return Boolean(element.closest("nav, aside, [data-testid*='sidebar'], [class*='sidebar']"));
+      });
+
+      if (!match) {
+        return false;
+      }
+
+      match.click();
+      return true;
+
+      function normalizeComparableText(value: string): string {
+        return value.replace(/\s+/g, " ").trim().toLowerCase();
+      }
+
+      function isDomElementVisible(element: HTMLElement): boolean {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+      }
+    }, projectName);
+
+    if (!clicked) {
+      throw new Error(`ChatGPT project "${projectName}" was not found in the sidebar.`);
+    }
+
+    await page.waitForLoadState("domcontentloaded").catch(() => undefined);
+    await page.waitForTimeout(800);
+    await this.waitForAuthenticatedPromptReadiness();
+  }
+
   private async waitForAuthenticatedPromptReadiness(): Promise<void> {
     const page = await this.getPage();
     await this.waitForChatGPTSurface();
@@ -309,6 +406,24 @@ export class ChatGPTBridge {
     this.page = existingChatPage ?? (await this.context.newPage());
     await this.page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
     await this.waitForChatGPTSurface();
+    await this.ensureProjectSelected();
+  }
+}
+
+async function expandProjectsSectionIfPresent(page: Page): Promise<void> {
+  const toggle = page
+    .locator("button,[role='button']")
+    .filter({ hasText: /projects|проекти|проєкти/i })
+    .first();
+
+  if (!(await toggle.isVisible().catch(() => false))) {
+    return;
+  }
+
+  const expanded = await toggle.getAttribute("aria-expanded").catch(() => null);
+  if (expanded === "false") {
+    await toggle.click({ timeout: limits.selectorTimeoutMs }).catch(() => undefined);
+    await page.waitForTimeout(400);
   }
 }
 

--- a/agent/bridge/factory.ts
+++ b/agent/bridge/factory.ts
@@ -1,12 +1,12 @@
 import { ExtensionChatGPTBridge } from "./chatgpt-extension.ts";
 import { ChatGPTBridge as PlaywrightChatGPTBridge } from "./chatgpt.ts";
-import type { ReasoningBridge } from "./types.ts";
+import type { ReasoningBridge, ReasoningBridgeOptions } from "./types.ts";
 
-export function createReasoningBridge(): ReasoningBridge {
+export function createReasoningBridge(options: ReasoningBridgeOptions = {}): ReasoningBridge {
   const mode = (process.env.CHATGPT_BRIDGE_MODE ?? "extension").toLowerCase();
   if (mode === "playwright") {
-    return new PlaywrightChatGPTBridge();
+    return new PlaywrightChatGPTBridge(options);
   }
 
-  return new ExtensionChatGPTBridge();
+  return new ExtensionChatGPTBridge(options);
 }

--- a/agent/bridge/types.ts
+++ b/agent/bridge/types.ts
@@ -1,5 +1,9 @@
 import type { BrowserContext } from "playwright";
 
+export type ReasoningBridgeOptions = {
+  projectName?: string;
+};
+
 export type ReasoningBridge = {
   initialize(): Promise<void>;
   openLoginWindow(): Promise<void>;

--- a/agent/core/agent-loop.ts
+++ b/agent/core/agent-loop.ts
@@ -25,7 +25,10 @@ export class AgentLoop {
   memory: MemoryStore;
   tools: Toolbox;
   availableTools: ToolName[];
+  workspaceRoot?: string;
   onEvent?: (event: MarshalRuntimeEvent) => Promise<void> | void;
+  verifiedFacts: string[];
+  recentFailures: string[];
 
   constructor(
     bridge: LoopBridge,
@@ -33,6 +36,7 @@ export class AgentLoop {
     tools: Toolbox,
     options?: {
       availableTools?: ToolName[];
+      workspaceRoot?: string;
       onEvent?: (event: MarshalRuntimeEvent) => Promise<void> | void;
     }
   ) {
@@ -40,7 +44,10 @@ export class AgentLoop {
     this.memory = memory;
     this.tools = tools;
     this.availableTools = options?.availableTools ?? ALL_TOOL_NAMES;
+    this.workspaceRoot = options?.workspaceRoot;
     this.onEvent = options?.onEvent;
+    this.verifiedFacts = [];
+    this.recentFailures = [];
   }
 
   async runTask(task: string, planSteps: string[]): Promise<string> {
@@ -68,7 +75,18 @@ export class AgentLoop {
     }
 
     const finalResponse = await withRetry(
-      async () => parseModelResponse(await this.bridge.ask(createFinalSynthesisPrompt(task, stepSummaries))),
+      async () =>
+        parseModelResponse(
+          await this.bridge.ask(
+            createFinalSynthesisPrompt({
+              task,
+              stepSummaries,
+              workspaceRoot: this.workspaceRoot,
+              recentFacts: this.verifiedFacts.slice(-6),
+              recentFailures: this.recentFailures.slice(-6)
+            })
+          )
+        ),
       {
         retries: limits.maxRetries,
         initialDelayMs: 500
@@ -112,6 +130,9 @@ export class AgentLoop {
         priorStepSummaries: input.stepSummaries,
         lastToolResult,
         memorySummary: await this.memory.summarize(),
+        workspaceRoot: this.workspaceRoot,
+        recentFacts: this.verifiedFacts.slice(-6),
+        recentFailures: this.recentFailures.slice(-6),
         availableTools: this.availableTools
       });
 
@@ -155,6 +176,7 @@ export class AgentLoop {
 
         const toolResult = await this.tools.execute(parsed.action, parsed.input);
         lastToolResult = formatToolResult(toolResult);
+        this.recordToolSuccess(toolResult);
         await this.memory.recordToolResult(lastToolResult);
         await this.learnFiles(toolResult);
         await this.emitEvent({
@@ -171,6 +193,7 @@ export class AgentLoop {
           ? createSelectorErrorMessage(message)
           : createToolErrorMessage(message);
         lastToolResult = JSON.stringify({ ok: false, error: message }, null, 2);
+        this.recordToolFailure(parsed.action, message);
         await this.memory.recordToolResult(lastToolResult);
         await this.emitEvent({
           type: "tool_failed",
@@ -205,5 +228,55 @@ export class AgentLoop {
 
   private async emitEvent(event: MarshalRuntimeEvent): Promise<void> {
     await this.onEvent?.(event);
+  }
+
+  private recordToolSuccess(result: { tool: string; data: Record<string, unknown>; summary: string }): void {
+    const detail = this.describeToolOutcome(result.tool, result.data, result.summary);
+    this.verifiedFacts.push(detail);
+    if (this.verifiedFacts.length > 20) {
+      this.verifiedFacts.shift();
+    }
+  }
+
+  private recordToolFailure(action: ToolName, error: string): void {
+    this.recentFailures.push(`${action} failed: ${error}`);
+    if (this.recentFailures.length > 20) {
+      this.recentFailures.shift();
+    }
+  }
+
+  private describeToolOutcome(tool: string, data: Record<string, unknown>, summary: string): string {
+    if (tool === "write_file") {
+      const filePath = String(data.path ?? "");
+      const bytes = Number(data.bytes ?? 0);
+      return `write_file succeeded for ${filePath || "unknown path"} (${bytes} bytes)`;
+    }
+
+    if (tool === "read_file") {
+      const filePath = String(data.path ?? "");
+      return `read_file succeeded for ${filePath || "unknown path"}`;
+    }
+
+    if (tool === "list_dir") {
+      const dirPath = String(data.path ?? ".");
+      const entries = Array.isArray(data.entries) ? data.entries.length : 0;
+      return `list_dir succeeded for ${dirPath} (${entries} entries)`;
+    }
+
+    if (tool === "run_shell") {
+      const cmd = String(data.cmd ?? "");
+      const exitCode = Number(data.exitCode ?? 0);
+      return `run_shell succeeded for "${cmd}" (exit ${exitCode})`;
+    }
+
+    if (tool === "browser_navigate") {
+      return `browser_navigate succeeded for ${String(data.url ?? "")}`;
+    }
+
+    if (tool === "browser_click" || tool === "browser_type") {
+      return `${tool} succeeded for selector ${String(data.selector ?? "")}`;
+    }
+
+    return summary;
   }
 }

--- a/agent/core/agent-loop.ts
+++ b/agent/core/agent-loop.ts
@@ -110,6 +110,8 @@ export class AgentLoop {
     const loopState = createLoopState();
     let iteration = 0;
     let lastToolResult: string | null = null;
+    let successfulToolsForStep = 0;
+    const requiresToolProof = stepRequiresSuccessfulTool(input.step);
 
     while (iteration < input.maxIterations) {
       iteration += 1;
@@ -148,6 +150,17 @@ export class AgentLoop {
       }
 
       if (parsed.kind === "final") {
+        if (requiresToolProof && successfulToolsForStep === 0) {
+          await this.bridge.ask(
+            [
+              "STEP COMPLETION BLOCKED.",
+              `The current step requires a successful tool result before FINAL is allowed: ${input.step}`,
+              "Use exactly one ACTION and wait for its RESULT before returning FINAL."
+            ].join("\n")
+          );
+          continue;
+        }
+
         await this.emitEvent({
           type: "step_completed",
           step: input.step,
@@ -176,6 +189,7 @@ export class AgentLoop {
 
         const toolResult = await this.tools.execute(parsed.action, parsed.input);
         lastToolResult = formatToolResult(toolResult);
+        successfulToolsForStep += 1;
         this.recordToolSuccess(toolResult);
         await this.memory.recordToolResult(lastToolResult);
         await this.learnFiles(toolResult);
@@ -279,4 +293,17 @@ export class AgentLoop {
 
     return summary;
   }
+}
+
+function stepRequiresSuccessfulTool(step: string): boolean {
+  const normalized = step.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  if (ALL_TOOL_NAMES.some((toolName) => normalized.includes(toolName))) {
+    return true;
+  }
+
+  return /(^|[\s"'])https?:\/\//.test(normalized) || /(^|[\s"'(])\/[^\s]*/.test(normalized);
 }

--- a/agent/core/protocol.ts
+++ b/agent/core/protocol.ts
@@ -96,6 +96,8 @@ export function createPlannerPrompt(
     "Create a concise execution plan for the task below.",
     'Return JSON only in the form {"steps":["step 1","step 2"]}.',
     "Keep steps concrete, sequential, and tool-oriented.",
+    "Each step must name the exact tool to use whenever a tool is required.",
+    "Do not include purely mental steps for filesystem, shell, or browser work.",
     options?.routeMode ? `Execution route: ${options.routeMode}.` : null,
     options?.availableTools?.length
       ? `Available tools:\n${getToolSchemas(options.availableTools)}`

--- a/agent/core/protocol.ts
+++ b/agent/core/protocol.ts
@@ -114,6 +114,9 @@ export function createStepPrompt(input: {
   priorStepSummaries: string[];
   lastToolResult: string | null;
   memorySummary: string;
+  workspaceRoot?: string;
+  recentFacts?: string[];
+  recentFailures?: string[];
   availableTools?: ToolName[];
 }): string {
   const completed =
@@ -123,21 +126,36 @@ export function createStepPrompt(input: {
 
   const lastToolResult = input.lastToolResult ?? "None";
   const toolSchemas = getToolSchemas(input.availableTools ?? ALL_TOOL_NAMES);
+  const recentFacts =
+    input.recentFacts && input.recentFacts.length > 0 ? input.recentFacts.map((item) => `- ${item}`).join("\n") : "None";
+  const recentFailures =
+    input.recentFailures && input.recentFailures.length > 0
+      ? input.recentFailures.map((item) => `- ${item}`).join("\n")
+      : "None";
 
   return [
     `Main task: ${input.task}`,
     `Current plan step (${input.stepIndex + 1}/${input.totalSteps}): ${input.step}`,
+    input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : null,
     `Completed step summaries:\n${completed}`,
     `Memory summary:\n${input.memorySummary}`,
+    `Recent verified facts:\n${recentFacts}`,
+    `Recent failures:\n${recentFailures}`,
     `Latest tool result:\n${lastToolResult}`,
     "Available tools:",
     toolSchemas,
     "Rules:",
     "- Use exactly one ACTION at a time.",
     "- Prefer inspecting state before mutating files.",
+    "- Only return FINAL when the current step is proven complete by successful tool results.",
+    "- Never claim a file was created, modified, read, verified, or listed unless a tool result in this task confirms it.",
+    "- If a tool failed, report the limitation accurately instead of claiming success.",
+    "- Filesystem and shell tools can only access paths inside the workspace root.",
     "- When the current step is complete, respond with FINAL: short step summary.",
     "- Do not include markdown fences or extra commentary."
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 export function createFormatErrorPrompt(error: string): string {
@@ -155,15 +173,35 @@ export function createFormatErrorPrompt(error: string): string {
   ].join("\n");
 }
 
-export function createFinalSynthesisPrompt(task: string, stepSummaries: string[]): string {
-  const lines = stepSummaries.map((item, index) => `${index + 1}. ${item}`).join("\n");
+export function createFinalSynthesisPrompt(input: {
+  task: string;
+  stepSummaries: string[];
+  workspaceRoot?: string;
+  recentFacts?: string[];
+  recentFailures?: string[];
+}): string {
+  const lines = input.stepSummaries.map((item, index) => `${index + 1}. ${item}`).join("\n");
+  const recentFacts =
+    input.recentFacts && input.recentFacts.length > 0 ? input.recentFacts.map((item) => `- ${item}`).join("\n") : "None";
+  const recentFailures =
+    input.recentFailures && input.recentFailures.length > 0
+      ? input.recentFailures.map((item) => `- ${item}`).join("\n")
+      : "None";
 
   return [
-    `Task: ${task}`,
+    `Task: ${input.task}`,
+    input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : null,
     `Completed step summaries:\n${lines || "None"}`,
+    `Verified facts:\n${recentFacts}`,
+    `Failures and limits:\n${recentFailures}`,
+    "Use only the verified facts and failures above.",
+    "Do not claim filesystem or shell side effects unless they were confirmed by a successful tool result.",
+    "If the task could not be completed because a requested path was outside the workspace root, say that explicitly.",
     "Return the final answer as:",
     "FINAL: concise result"
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 export function formatToolResult(result: ToolExecutionResult): string {

--- a/agent/runtime/marshal.ts
+++ b/agent/runtime/marshal.ts
@@ -35,7 +35,7 @@ export async function runMarshalTask(options: RunMarshalTaskOptions): Promise<st
   const sandbox = new FileSandbox(options.workspaceRoot);
   const browserManager = new PlaywrightBrowserManager(false);
   const allowedTools = ROUTE_TOOL_MAP[route];
-  const task = buildExecutionTask(options.task, route, options.attachments ?? []);
+  const task = buildExecutionTask(options.task, route, options.attachments ?? [], sandbox.root);
 
   try {
     await Promise.all([bridge.initialize(), memory.initialize(), sandbox.initialize()]);
@@ -69,6 +69,7 @@ export async function runMarshalTask(options: RunMarshalTaskOptions): Promise<st
     );
     const agentLoop = new AgentLoop(bridge, memory, tools, {
       availableTools: allowedTools,
+      workspaceRoot: sandbox.root,
       onEvent: options.onEvent
     });
     const result = await agentLoop.runTask(task, plan.steps);
@@ -102,13 +103,26 @@ export function getDefaultSessionMemory(sessionId: string): string {
   return path.resolve(process.cwd(), "operator-data", "sessions", sessionId, "memory");
 }
 
-function buildExecutionTask(task: string, route: ExecutionRoute, attachments: RuntimeAttachment[]): string {
+function buildExecutionTask(
+  task: string,
+  route: ExecutionRoute,
+  attachments: RuntimeAttachment[],
+  workspaceRoot: string
+): string {
   const routeInstructions =
     route === "auto"
       ? "Execution route: auto. Use the available tools that best fit the task."
       : route === "local"
         ? "Execution route: local only. Do not rely on browser automation."
         : "Execution route: browser only. Do not rely on local filesystem or shell tools.";
+  const workspaceInstructions =
+    route === "browser"
+      ? "Local workspace access is disabled for this task."
+      : [
+          `Workspace root: ${workspaceRoot}`,
+          "Filesystem and shell tools can only access paths inside this workspace root.",
+          "If the user requests an absolute path or any location outside this workspace root, do not claim success there. State the limitation clearly."
+        ].join("\n");
 
   const attachmentBlock =
     attachments.length === 0
@@ -121,5 +135,5 @@ function buildExecutionTask(task: string, route: ExecutionRoute, attachments: Ru
           )
         ].join("\n");
 
-  return [routeInstructions, attachmentBlock, "User request:", task].join("\n\n");
+  return [routeInstructions, workspaceInstructions, attachmentBlock, "User request:", task].join("\n\n");
 }

--- a/agent/runtime/marshal.ts
+++ b/agent/runtime/marshal.ts
@@ -24,12 +24,13 @@ export type RunMarshalTaskOptions = {
   attachments?: RuntimeAttachment[];
   workspaceRoot?: string;
   memoryDir?: string;
+  chatProjectName?: string;
   onEvent?: (event: MarshalRuntimeEvent) => Promise<void> | void;
 };
 
 export async function runMarshalTask(options: RunMarshalTaskOptions): Promise<string> {
   const route = options.route ?? "auto";
-  const bridge = createReasoningBridge();
+  const bridge = createReasoningBridge({ projectName: options.chatProjectName });
   const memory = new MemoryStore(options.memoryDir);
   const sandbox = new FileSandbox(options.workspaceRoot);
   const browserManager = new PlaywrightBrowserManager(false);

--- a/chrome-extension/src/content.ts
+++ b/chrome-extension/src/content.ts
@@ -42,6 +42,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 async function executeCommand(command: BridgeCommand): Promise<CommandResult> {
   switch (command.kind) {
     case "reset_conversation":
+      await ensureProjectSelected(typeof command.payload.projectName === "string" ? command.payload.projectName : "");
       await resetConversation();
       return { ok: true, data: { state: collectPageState().state } };
     case "send_prompt": {
@@ -49,6 +50,8 @@ async function executeCommand(command: BridgeCommand): Promise<CommandResult> {
       if (!prompt) {
         return { ok: false, error: "Prompt is empty." };
       }
+
+      await ensureProjectSelected(typeof command.payload.projectName === "string" ? command.payload.projectName : "");
 
       if (collectPageState().state !== "ready") {
         return { ok: false, error: "ChatGPT is not on a ready composer surface." };
@@ -226,6 +229,27 @@ async function resetConversation(): Promise<void> {
   await sleep(500);
 }
 
+async function ensureProjectSelected(projectName: string): Promise<void> {
+  const normalizedProjectName = normalizeComparableText(projectName);
+  if (!normalizedProjectName) {
+    return;
+  }
+
+  if (isProjectCurrentlySelected(normalizedProjectName)) {
+    return;
+  }
+
+  expandProjectsSectionIfNeeded();
+
+  const projectEntry = findSidebarProjectEntry(normalizedProjectName);
+  if (!projectEntry) {
+    throw new Error(`ChatGPT project "${projectName}" was not found in the sidebar.`);
+  }
+
+  projectEntry.click();
+  await waitForReadySurface();
+}
+
 function extractLatestAssistantText(): string {
   const assistantMessages = Array.from(
     document.querySelectorAll("[data-message-author-role='assistant']")
@@ -292,8 +316,79 @@ function findElementsWithText(selector: string, pattern: RegExp): HTMLElement[] 
   }) as HTMLElement[];
 }
 
+function findSidebarProjectEntry(normalizedProjectName: string): HTMLElement | null {
+  const candidates = Array.from(document.querySelectorAll("a,button,[role='button']")).filter((element) => {
+    if (!isVisible(element)) {
+      return false;
+    }
+
+    const container = element.closest("nav, aside, [data-testid*='sidebar'], [class*='sidebar']");
+    if (!container) {
+      return false;
+    }
+
+    const text = normalizeComparableText(
+      [
+        element.textContent ?? "",
+        element.getAttribute("aria-label") ?? "",
+        element.getAttribute("title") ?? ""
+      ].join(" ")
+    );
+
+    return text === normalizedProjectName;
+  }) as HTMLElement[];
+
+  return candidates[0] ?? null;
+}
+
+function isProjectCurrentlySelected(normalizedProjectName: string): boolean {
+  const candidates = Array.from(
+    document.querySelectorAll("main h1, main h2, nav a, nav button, aside a, aside button")
+  ) as HTMLElement[];
+
+  return candidates.some((element) => {
+    if (!isVisible(element)) {
+      return false;
+    }
+
+    const text = normalizeComparableText(
+      [element.textContent ?? "", element.getAttribute("aria-label") ?? ""].join(" ")
+    );
+
+    return text === normalizedProjectName && element.getAttribute("aria-current") === "page";
+  });
+}
+
+function expandProjectsSectionIfNeeded(): void {
+  const toggle = findElementsWithText("button,[role='button']", /(projects|проекти|проєкти)/i)[0];
+  if (!toggle) {
+    return;
+  }
+
+  if (toggle.getAttribute("aria-expanded") === "false") {
+    toggle.click();
+  }
+}
+
+async function waitForReadySurface(timeoutMs = 15_000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (detectPageState() === "ready") {
+      return;
+    }
+
+    await sleep(250);
+  }
+
+  throw new Error("Timed out while waiting for the selected ChatGPT project to load.");
+}
+
 function normalizeText(value: string): string {
   return value.replace(/\u200b/g, "").replace(/\s+\n/g, "\n").replace(/\s+/g, " ").trim();
+}
+
+function normalizeComparableText(value: string): string {
+  return normalizeText(value).toLowerCase();
 }
 
 function sleep(ms: number): Promise<void> {

--- a/dist/agent/bridge/chatgpt-extension.js
+++ b/dist/agent/bridge/chatgpt-extension.js
@@ -2,8 +2,10 @@ import { LocalBridgeServer } from "./local-bridge-server.js";
 export class ExtensionChatGPTBridge {
     server;
     primed = false;
-    constructor(server = new LocalBridgeServer()) {
+    projectName;
+    constructor(options = {}, server = new LocalBridgeServer()) {
         this.server = server;
+        this.projectName = options.projectName?.trim() || process.env.CHATGPT_PROJECT_NAME?.trim() || null;
     }
     async initialize() {
         await this.server.start();
@@ -18,7 +20,7 @@ export class ExtensionChatGPTBridge {
     }
     async resetConversation() {
         await this.initialize();
-        const result = await this.server.sendCommand("reset_conversation", {});
+        const result = await this.server.sendCommand("reset_conversation", this.getProjectPayload());
         if (!result.ok) {
             throw new Error(result.error ?? "Extension failed to reset the ChatGPT conversation.");
         }
@@ -32,7 +34,10 @@ export class ExtensionChatGPTBridge {
     }
     async ask(prompt) {
         await this.initialize();
-        const result = await this.server.sendCommand("send_prompt", { prompt });
+        const result = await this.server.sendCommand("send_prompt", {
+            prompt,
+            ...this.getProjectPayload()
+        });
         if (!result.ok) {
             throw new Error(result.error ?? "Extension failed to send the prompt to ChatGPT.");
         }
@@ -45,5 +50,8 @@ export class ExtensionChatGPTBridge {
     async close() {
         await this.server.close();
         this.primed = false;
+    }
+    getProjectPayload() {
+        return this.projectName ? { projectName: this.projectName } : {};
     }
 }

--- a/dist/agent/bridge/chatgpt.js
+++ b/dist/agent/bridge/chatgpt.js
@@ -23,7 +23,8 @@ export class ChatGPTBridge {
                 path.resolve(process.cwd(), "agent/.auth/chatgpt-storage.json"),
             userDataDir: process.env.CHATGPT_USER_DATA_DIR ?? path.resolve(process.cwd(), "agent/.chrome-profile"),
             executablePath: resolveChromeExecutable(process.env.CHATGPT_BROWSER_EXECUTABLE_PATH ?? undefined),
-            cdpUrl: process.env.CHATGPT_CDP_URL ?? undefined
+            cdpUrl: process.env.CHATGPT_CDP_URL ?? undefined,
+            projectName: options.projectName?.trim() || process.env.CHATGPT_PROJECT_NAME?.trim() || undefined
         };
     }
     async initialize() {
@@ -39,6 +40,7 @@ export class ChatGPTBridge {
         this.page = this.context.pages()[0] ?? (await this.context.newPage());
         await this.page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
         await this.waitForChatGPTSurface();
+        await this.ensureProjectSelected();
         await clickNewChatIfAvailable(this.page, this.selectorCache);
         if (!storageState) {
             await this.captureStorageStateAfterManualLogin();
@@ -63,6 +65,7 @@ export class ChatGPTBridge {
         const page = await this.getPage();
         await page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
         await this.waitForChatGPTSurface();
+        await this.ensureProjectSelected();
         await clickNewChatIfAvailable(page, this.selectorCache);
         this.primed = false;
     }
@@ -102,6 +105,7 @@ export class ChatGPTBridge {
     async sendPrompt(prompt) {
         const page = await this.getPage();
         await this.ensureReadyForPrompt();
+        await this.ensureProjectSelected();
         const composer = await withRetry(async () => resolveComposer(page, this.selectorCache), { retries: limits.maxRetries, initialDelayMs: 500 });
         const previousAssistantText = await this.extractLatestAssistantText();
         await composer.click({ timeout: limits.selectorTimeoutMs });
@@ -186,6 +190,73 @@ export class ChatGPTBridge {
             throw new Error("ChatGPT is showing the logged-out homepage. Complete login to reuse a real session.");
         }
     }
+    async ensureProjectSelected() {
+        const projectName = this.options.projectName?.trim();
+        if (!projectName) {
+            return;
+        }
+        const page = await this.getPage();
+        const alreadySelected = await page.evaluate((targetName) => {
+            const normalizedTarget = normalizeComparableText(targetName);
+            const candidates = Array.from(document.querySelectorAll("main h1, main h2, nav a, nav button, aside a, aside button"));
+            return candidates.some((element) => {
+                if (!isDomElementVisible(element)) {
+                    return false;
+                }
+                const text = normalizeComparableText([element.textContent ?? "", element.getAttribute("aria-label") ?? ""].join(" "));
+                return text === normalizedTarget && element.getAttribute("aria-current") === "page";
+            });
+            function normalizeComparableText(value) {
+                return value.replace(/\s+/g, " ").trim().toLowerCase();
+            }
+            function isDomElementVisible(element) {
+                const style = window.getComputedStyle(element);
+                const rect = element.getBoundingClientRect();
+                return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+            }
+        }, projectName);
+        if (alreadySelected) {
+            return;
+        }
+        await expandProjectsSectionIfPresent(page);
+        const clicked = await page.evaluate((targetName) => {
+            const normalizedTarget = normalizeComparableText(targetName);
+            const candidates = Array.from(document.querySelectorAll("a,button,[role='button']"));
+            const match = candidates.find((element) => {
+                if (!isDomElementVisible(element)) {
+                    return false;
+                }
+                const text = normalizeComparableText([
+                    element.textContent ?? "",
+                    element.getAttribute("aria-label") ?? "",
+                    element.getAttribute("title") ?? ""
+                ].join(" "));
+                if (text !== normalizedTarget) {
+                    return false;
+                }
+                return Boolean(element.closest("nav, aside, [data-testid*='sidebar'], [class*='sidebar']"));
+            });
+            if (!match) {
+                return false;
+            }
+            match.click();
+            return true;
+            function normalizeComparableText(value) {
+                return value.replace(/\s+/g, " ").trim().toLowerCase();
+            }
+            function isDomElementVisible(element) {
+                const style = window.getComputedStyle(element);
+                const rect = element.getBoundingClientRect();
+                return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+            }
+        }, projectName);
+        if (!clicked) {
+            throw new Error(`ChatGPT project "${projectName}" was not found in the sidebar.`);
+        }
+        await page.waitForLoadState("domcontentloaded").catch(() => undefined);
+        await page.waitForTimeout(800);
+        await this.waitForAuthenticatedPromptReadiness();
+    }
     async waitForAuthenticatedPromptReadiness() {
         const page = await this.getPage();
         await this.waitForChatGPTSurface();
@@ -228,6 +299,21 @@ export class ChatGPTBridge {
         this.page = existingChatPage ?? (await this.context.newPage());
         await this.page.goto(this.options.chatgptUrl, { waitUntil: "domcontentloaded" });
         await this.waitForChatGPTSurface();
+        await this.ensureProjectSelected();
+    }
+}
+async function expandProjectsSectionIfPresent(page) {
+    const toggle = page
+        .locator("button,[role='button']")
+        .filter({ hasText: /projects|проекти|проєкти/i })
+        .first();
+    if (!(await toggle.isVisible().catch(() => false))) {
+        return;
+    }
+    const expanded = await toggle.getAttribute("aria-expanded").catch(() => null);
+    if (expanded === "false") {
+        await toggle.click({ timeout: limits.selectorTimeoutMs }).catch(() => undefined);
+        await page.waitForTimeout(400);
     }
 }
 function parseBoolean(value, fallback) {

--- a/dist/agent/bridge/factory.js
+++ b/dist/agent/bridge/factory.js
@@ -1,9 +1,9 @@
 import { ExtensionChatGPTBridge } from "./chatgpt-extension.js";
 import { ChatGPTBridge as PlaywrightChatGPTBridge } from "./chatgpt.js";
-export function createReasoningBridge() {
+export function createReasoningBridge(options = {}) {
     const mode = (process.env.CHATGPT_BRIDGE_MODE ?? "extension").toLowerCase();
     if (mode === "playwright") {
-        return new PlaywrightChatGPTBridge();
+        return new PlaywrightChatGPTBridge(options);
     }
-    return new ExtensionChatGPTBridge();
+    return new ExtensionChatGPTBridge(options);
 }

--- a/dist/agent/core/agent-loop.js
+++ b/dist/agent/core/agent-loop.js
@@ -61,6 +61,8 @@ export class AgentLoop {
         const loopState = createLoopState();
         let iteration = 0;
         let lastToolResult = null;
+        let successfulToolsForStep = 0;
+        const requiresToolProof = stepRequiresSuccessfulTool(input.step);
         while (iteration < input.maxIterations) {
             iteration += 1;
             await this.memory.setCurrentStep(input.step, iteration);
@@ -95,6 +97,14 @@ export class AgentLoop {
                 continue;
             }
             if (parsed.kind === "final") {
+                if (requiresToolProof && successfulToolsForStep === 0) {
+                    await this.bridge.ask([
+                        "STEP COMPLETION BLOCKED.",
+                        `The current step requires a successful tool result before FINAL is allowed: ${input.step}`,
+                        "Use exactly one ACTION and wait for its RESULT before returning FINAL."
+                    ].join("\n"));
+                    continue;
+                }
                 await this.emitEvent({
                     type: "step_completed",
                     step: input.step,
@@ -121,6 +131,7 @@ export class AgentLoop {
                 });
                 const toolResult = await this.tools.execute(parsed.action, parsed.input);
                 lastToolResult = formatToolResult(toolResult);
+                successfulToolsForStep += 1;
                 this.recordToolSuccess(toolResult);
                 await this.memory.recordToolResult(lastToolResult);
                 await this.learnFiles(toolResult);
@@ -212,4 +223,14 @@ export class AgentLoop {
         }
         return summary;
     }
+}
+function stepRequiresSuccessfulTool(step) {
+    const normalized = step.trim().toLowerCase();
+    if (!normalized) {
+        return false;
+    }
+    if (ALL_TOOL_NAMES.some((toolName) => normalized.includes(toolName))) {
+        return true;
+    }
+    return /(^|[\s"'])https?:\/\//.test(normalized) || /(^|[\s"'(])\/[^\s]*/.test(normalized);
 }

--- a/dist/agent/core/agent-loop.js
+++ b/dist/agent/core/agent-loop.js
@@ -9,13 +9,19 @@ export class AgentLoop {
     memory;
     tools;
     availableTools;
+    workspaceRoot;
     onEvent;
+    verifiedFacts;
+    recentFailures;
     constructor(bridge, memory, tools, options) {
         this.bridge = bridge;
         this.memory = memory;
         this.tools = tools;
         this.availableTools = options?.availableTools ?? ALL_TOOL_NAMES;
+        this.workspaceRoot = options?.workspaceRoot;
         this.onEvent = options?.onEvent;
+        this.verifiedFacts = [];
+        this.recentFailures = [];
     }
     async runTask(task, planSteps) {
         await this.memory.setActiveTask(task, planSteps);
@@ -37,7 +43,13 @@ export class AgentLoop {
             stepSummaries.push(result.summary);
             usedIterations += result.iterationsUsed;
         }
-        const finalResponse = await withRetry(async () => parseModelResponse(await this.bridge.ask(createFinalSynthesisPrompt(task, stepSummaries))), {
+        const finalResponse = await withRetry(async () => parseModelResponse(await this.bridge.ask(createFinalSynthesisPrompt({
+            task,
+            stepSummaries,
+            workspaceRoot: this.workspaceRoot,
+            recentFacts: this.verifiedFacts.slice(-6),
+            recentFailures: this.recentFailures.slice(-6)
+        }))), {
             retries: limits.maxRetries,
             initialDelayMs: 500
         });
@@ -67,6 +79,9 @@ export class AgentLoop {
                 priorStepSummaries: input.stepSummaries,
                 lastToolResult,
                 memorySummary: await this.memory.summarize(),
+                workspaceRoot: this.workspaceRoot,
+                recentFacts: this.verifiedFacts.slice(-6),
+                recentFailures: this.recentFailures.slice(-6),
                 availableTools: this.availableTools
             });
             const raw = await this.bridge.ask(prompt);
@@ -106,6 +121,7 @@ export class AgentLoop {
                 });
                 const toolResult = await this.tools.execute(parsed.action, parsed.input);
                 lastToolResult = formatToolResult(toolResult);
+                this.recordToolSuccess(toolResult);
                 await this.memory.recordToolResult(lastToolResult);
                 await this.learnFiles(toolResult);
                 await this.emitEvent({
@@ -123,6 +139,7 @@ export class AgentLoop {
                     ? createSelectorErrorMessage(message)
                     : createToolErrorMessage(message);
                 lastToolResult = JSON.stringify({ ok: false, error: message }, null, 2);
+                this.recordToolFailure(parsed.action, message);
                 await this.memory.recordToolResult(lastToolResult);
                 await this.emitEvent({
                     type: "tool_failed",
@@ -153,5 +170,46 @@ export class AgentLoop {
     }
     async emitEvent(event) {
         await this.onEvent?.(event);
+    }
+    recordToolSuccess(result) {
+        const detail = this.describeToolOutcome(result.tool, result.data, result.summary);
+        this.verifiedFacts.push(detail);
+        if (this.verifiedFacts.length > 20) {
+            this.verifiedFacts.shift();
+        }
+    }
+    recordToolFailure(action, error) {
+        this.recentFailures.push(`${action} failed: ${error}`);
+        if (this.recentFailures.length > 20) {
+            this.recentFailures.shift();
+        }
+    }
+    describeToolOutcome(tool, data, summary) {
+        if (tool === "write_file") {
+            const filePath = String(data.path ?? "");
+            const bytes = Number(data.bytes ?? 0);
+            return `write_file succeeded for ${filePath || "unknown path"} (${bytes} bytes)`;
+        }
+        if (tool === "read_file") {
+            const filePath = String(data.path ?? "");
+            return `read_file succeeded for ${filePath || "unknown path"}`;
+        }
+        if (tool === "list_dir") {
+            const dirPath = String(data.path ?? ".");
+            const entries = Array.isArray(data.entries) ? data.entries.length : 0;
+            return `list_dir succeeded for ${dirPath} (${entries} entries)`;
+        }
+        if (tool === "run_shell") {
+            const cmd = String(data.cmd ?? "");
+            const exitCode = Number(data.exitCode ?? 0);
+            return `run_shell succeeded for "${cmd}" (exit ${exitCode})`;
+        }
+        if (tool === "browser_navigate") {
+            return `browser_navigate succeeded for ${String(data.url ?? "")}`;
+        }
+        if (tool === "browser_click" || tool === "browser_type") {
+            return `${tool} succeeded for selector ${String(data.selector ?? "")}`;
+        }
+        return summary;
     }
 }

--- a/dist/agent/core/protocol.js
+++ b/dist/agent/core/protocol.js
@@ -61,20 +61,33 @@ export function createStepPrompt(input) {
         : input.priorStepSummaries.map((item, index) => `${index + 1}. ${item}`).join("\n");
     const lastToolResult = input.lastToolResult ?? "None";
     const toolSchemas = getToolSchemas(input.availableTools ?? ALL_TOOL_NAMES);
+    const recentFacts = input.recentFacts && input.recentFacts.length > 0 ? input.recentFacts.map((item) => `- ${item}`).join("\n") : "None";
+    const recentFailures = input.recentFailures && input.recentFailures.length > 0
+        ? input.recentFailures.map((item) => `- ${item}`).join("\n")
+        : "None";
     return [
         `Main task: ${input.task}`,
         `Current plan step (${input.stepIndex + 1}/${input.totalSteps}): ${input.step}`,
+        input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : null,
         `Completed step summaries:\n${completed}`,
         `Memory summary:\n${input.memorySummary}`,
+        `Recent verified facts:\n${recentFacts}`,
+        `Recent failures:\n${recentFailures}`,
         `Latest tool result:\n${lastToolResult}`,
         "Available tools:",
         toolSchemas,
         "Rules:",
         "- Use exactly one ACTION at a time.",
         "- Prefer inspecting state before mutating files.",
+        "- Only return FINAL when the current step is proven complete by successful tool results.",
+        "- Never claim a file was created, modified, read, verified, or listed unless a tool result in this task confirms it.",
+        "- If a tool failed, report the limitation accurately instead of claiming success.",
+        "- Filesystem and shell tools can only access paths inside the workspace root.",
         "- When the current step is complete, respond with FINAL: short step summary.",
         "- Do not include markdown fences or extra commentary."
-    ].join("\n\n");
+    ]
+        .filter(Boolean)
+        .join("\n\n");
 }
 export function createFormatErrorPrompt(error) {
     return [
@@ -90,14 +103,26 @@ export function createFormatErrorPrompt(error) {
         "FINAL: result"
     ].join("\n");
 }
-export function createFinalSynthesisPrompt(task, stepSummaries) {
-    const lines = stepSummaries.map((item, index) => `${index + 1}. ${item}`).join("\n");
+export function createFinalSynthesisPrompt(input) {
+    const lines = input.stepSummaries.map((item, index) => `${index + 1}. ${item}`).join("\n");
+    const recentFacts = input.recentFacts && input.recentFacts.length > 0 ? input.recentFacts.map((item) => `- ${item}`).join("\n") : "None";
+    const recentFailures = input.recentFailures && input.recentFailures.length > 0
+        ? input.recentFailures.map((item) => `- ${item}`).join("\n")
+        : "None";
     return [
-        `Task: ${task}`,
+        `Task: ${input.task}`,
+        input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : null,
         `Completed step summaries:\n${lines || "None"}`,
+        `Verified facts:\n${recentFacts}`,
+        `Failures and limits:\n${recentFailures}`,
+        "Use only the verified facts and failures above.",
+        "Do not claim filesystem or shell side effects unless they were confirmed by a successful tool result.",
+        "If the task could not be completed because a requested path was outside the workspace root, say that explicitly.",
         "Return the final answer as:",
         "FINAL: concise result"
-    ].join("\n\n");
+    ]
+        .filter(Boolean)
+        .join("\n\n");
 }
 export function formatToolResult(result) {
     return JSON.stringify({

--- a/dist/agent/core/protocol.js
+++ b/dist/agent/core/protocol.js
@@ -46,6 +46,8 @@ export function createPlannerPrompt(task, options) {
         "Create a concise execution plan for the task below.",
         'Return JSON only in the form {"steps":["step 1","step 2"]}.',
         "Keep steps concrete, sequential, and tool-oriented.",
+        "Each step must name the exact tool to use whenever a tool is required.",
+        "Do not include purely mental steps for filesystem, shell, or browser work.",
         options?.routeMode ? `Execution route: ${options.routeMode}.` : null,
         options?.availableTools?.length
             ? `Available tools:\n${getToolSchemas(options.availableTools)}`

--- a/dist/agent/runtime/marshal.js
+++ b/dist/agent/runtime/marshal.js
@@ -21,7 +21,7 @@ export async function runMarshalTask(options) {
     const sandbox = new FileSandbox(options.workspaceRoot);
     const browserManager = new PlaywrightBrowserManager(false);
     const allowedTools = ROUTE_TOOL_MAP[route];
-    const task = buildExecutionTask(options.task, route, options.attachments ?? []);
+    const task = buildExecutionTask(options.task, route, options.attachments ?? [], sandbox.root);
     try {
         await Promise.all([bridge.initialize(), memory.initialize(), sandbox.initialize()]);
         await options.onEvent?.({
@@ -47,6 +47,7 @@ export async function runMarshalTask(options) {
         const tools = new Toolbox(sandbox, new ShellTool(sandbox.root), new BrowserTool(browserManager), allowedTools);
         const agentLoop = new AgentLoop(bridge, memory, tools, {
             availableTools: allowedTools,
+            workspaceRoot: sandbox.root,
             onEvent: options.onEvent
         });
         const result = await agentLoop.runTask(task, plan.steps);
@@ -78,17 +79,24 @@ export function getDefaultSessionWorkspace(sessionId) {
 export function getDefaultSessionMemory(sessionId) {
     return path.resolve(process.cwd(), "operator-data", "sessions", sessionId, "memory");
 }
-function buildExecutionTask(task, route, attachments) {
+function buildExecutionTask(task, route, attachments, workspaceRoot) {
     const routeInstructions = route === "auto"
         ? "Execution route: auto. Use the available tools that best fit the task."
         : route === "local"
             ? "Execution route: local only. Do not rely on browser automation."
             : "Execution route: browser only. Do not rely on local filesystem or shell tools.";
+    const workspaceInstructions = route === "browser"
+        ? "Local workspace access is disabled for this task."
+        : [
+            `Workspace root: ${workspaceRoot}`,
+            "Filesystem and shell tools can only access paths inside this workspace root.",
+            "If the user requests an absolute path or any location outside this workspace root, do not claim success there. State the limitation clearly."
+        ].join("\n");
     const attachmentBlock = attachments.length === 0
         ? "Attachments: none."
         : [
             "Attachments:",
             ...attachments.map((attachment, index) => `${index + 1}. ${attachment.name} (${attachment.mimeType}, ${attachment.size} bytes) at workspace path ${attachment.relativePath}`)
         ].join("\n");
-    return [routeInstructions, attachmentBlock, "User request:", task].join("\n\n");
+    return [routeInstructions, workspaceInstructions, attachmentBlock, "User request:", task].join("\n\n");
 }

--- a/dist/agent/runtime/marshal.js
+++ b/dist/agent/runtime/marshal.js
@@ -16,7 +16,7 @@ const ROUTE_TOOL_MAP = {
 };
 export async function runMarshalTask(options) {
     const route = options.route ?? "auto";
-    const bridge = createReasoningBridge();
+    const bridge = createReasoningBridge({ projectName: options.chatProjectName });
     const memory = new MemoryStore(options.memoryDir);
     const sandbox = new FileSandbox(options.workspaceRoot);
     const browserManager = new PlaywrightBrowserManager(false);

--- a/dist/chrome-extension/src/content.js
+++ b/dist/chrome-extension/src/content.js
@@ -24,6 +24,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 async function executeCommand(command) {
     switch (command.kind) {
         case "reset_conversation":
+            await ensureProjectSelected(typeof command.payload.projectName === "string" ? command.payload.projectName : "");
             await resetConversation();
             return { ok: true, data: { state: collectPageState().state } };
         case "send_prompt": {
@@ -31,6 +32,7 @@ async function executeCommand(command) {
             if (!prompt) {
                 return { ok: false, error: "Prompt is empty." };
             }
+            await ensureProjectSelected(typeof command.payload.projectName === "string" ? command.payload.projectName : "");
             if (collectPageState().state !== "ready") {
                 return { ok: false, error: "ChatGPT is not on a ready composer surface." };
             }
@@ -165,6 +167,22 @@ async function resetConversation() {
     newChat.click();
     await sleep(500);
 }
+async function ensureProjectSelected(projectName) {
+    const normalizedProjectName = normalizeComparableText(projectName);
+    if (!normalizedProjectName) {
+        return;
+    }
+    if (isProjectCurrentlySelected(normalizedProjectName)) {
+        return;
+    }
+    expandProjectsSectionIfNeeded();
+    const projectEntry = findSidebarProjectEntry(normalizedProjectName);
+    if (!projectEntry) {
+        throw new Error(`ChatGPT project "${projectName}" was not found in the sidebar.`);
+    }
+    projectEntry.click();
+    await waitForReadySurface();
+}
 function extractLatestAssistantText() {
     const assistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"))
         .map((element) => normalizeText(element.innerText || element.textContent || ""))
@@ -217,8 +235,58 @@ function findElementsWithText(selector, pattern) {
         return pattern.test(text);
     });
 }
+function findSidebarProjectEntry(normalizedProjectName) {
+    const candidates = Array.from(document.querySelectorAll("a,button,[role='button']")).filter((element) => {
+        if (!isVisible(element)) {
+            return false;
+        }
+        const container = element.closest("nav, aside, [data-testid*='sidebar'], [class*='sidebar']");
+        if (!container) {
+            return false;
+        }
+        const text = normalizeComparableText([
+            element.textContent ?? "",
+            element.getAttribute("aria-label") ?? "",
+            element.getAttribute("title") ?? ""
+        ].join(" "));
+        return text === normalizedProjectName;
+    });
+    return candidates[0] ?? null;
+}
+function isProjectCurrentlySelected(normalizedProjectName) {
+    const candidates = Array.from(document.querySelectorAll("main h1, main h2, nav a, nav button, aside a, aside button"));
+    return candidates.some((element) => {
+        if (!isVisible(element)) {
+            return false;
+        }
+        const text = normalizeComparableText([element.textContent ?? "", element.getAttribute("aria-label") ?? ""].join(" "));
+        return text === normalizedProjectName && element.getAttribute("aria-current") === "page";
+    });
+}
+function expandProjectsSectionIfNeeded() {
+    const toggle = findElementsWithText("button,[role='button']", /(projects|проекти|проєкти)/i)[0];
+    if (!toggle) {
+        return;
+    }
+    if (toggle.getAttribute("aria-expanded") === "false") {
+        toggle.click();
+    }
+}
+async function waitForReadySurface(timeoutMs = 15_000) {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+        if (detectPageState() === "ready") {
+            return;
+        }
+        await sleep(250);
+    }
+    throw new Error("Timed out while waiting for the selected ChatGPT project to load.");
+}
 function normalizeText(value) {
     return value.replace(/\u200b/g, "").replace(/\s+\n/g, "\n").replace(/\s+/g, " ").trim();
+}
+function normalizeComparableText(value) {
+    return normalizeText(value).toLowerCase();
 }
 function sleep(ms) {
     return new Promise((resolve) => window.setTimeout(resolve, ms));

--- a/dist/operator/server.js
+++ b/dist/operator/server.js
@@ -8,7 +8,7 @@ export class OperatorServer {
     port;
     store;
     server = null;
-    queueTail = Promise.resolve();
+    sessionQueueTails = new Map();
     constructor(port = Number(process.env.OPERATOR_WEB_PORT ?? "3489"), store = new OperatorSessionStore()) {
         this.port = port;
         this.store = store;
@@ -31,6 +31,7 @@ export class OperatorServer {
             this.server?.listen(this.port, "127.0.0.1", () => resolve());
             this.server?.once("error", reject);
         });
+        await this.resumePendingTasks();
     }
     async close() {
         if (!this.server) {
@@ -44,30 +45,53 @@ export class OperatorServer {
     async handleRequest(request, response) {
         const url = new URL(request.url ?? "/", `http://127.0.0.1:${this.port}`);
         if (request.method === "GET" && url.pathname === "/api/health") {
+            const sessions = await this.store.listSessions();
+            const projects = await this.store.listProjects();
+            const queuedTasks = sessions.filter((session) => session.activeTaskStatus === "queued").length;
+            const runningTasks = sessions.filter((session) => session.activeTaskStatus === "running").length;
             writeJson(response, 200, {
                 ok: true,
                 data: {
                     port: this.port,
-                    queued: true
+                    projectCount: projects.length,
+                    sessionCount: sessions.length,
+                    queuedTasks,
+                    runningTasks
                 }
             });
             return;
         }
+        if (request.method === "GET" && url.pathname === "/api/projects") {
+            const projects = await this.store.listProjects();
+            writeJson(response, 200, { ok: true, data: projects });
+            return;
+        }
+        if (request.method === "POST" && url.pathname === "/api/projects") {
+            const body = await readJsonBody(request);
+            const project = await this.store.createProject(typeof body.name === "string" ? body.name : undefined);
+            writeJson(response, 201, { ok: true, data: project });
+            return;
+        }
         if (request.method === "GET" && url.pathname === "/api/sessions") {
-            const sessions = await this.store.listSessions();
+            const sessions = await this.store.listSessions(url.searchParams.get("projectId") ?? undefined);
             writeJson(response, 200, { ok: true, data: sessions });
             return;
         }
         if (request.method === "POST" && url.pathname === "/api/sessions") {
             const body = await readJsonBody(request);
-            const session = await this.store.createSession(typeof body.title === "string" ? body.title : undefined);
+            const session = await this.store.createSession(typeof body.title === "string" ? body.title : undefined, typeof body.projectId === "string" ? body.projectId : undefined);
             writeJson(response, 201, { ok: true, data: session });
             return;
         }
         const sessionMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)$/);
         if (request.method === "GET" && sessionMatch) {
-            const session = await this.store.readSession(sessionMatch[1]);
+            const session = await this.store.readSession(sessionMatch[1], url.searchParams.get("projectId") ?? undefined);
             writeJson(response, 200, { ok: true, data: session });
+            return;
+        }
+        if (request.method === "DELETE" && sessionMatch) {
+            await this.store.deleteSession(sessionMatch[1], url.searchParams.get("projectId") ?? undefined);
+            writeJson(response, 200, { ok: true });
             return;
         }
         const messageMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/messages$/);
@@ -78,12 +102,13 @@ export class OperatorServer {
             const uploads = Array.isArray(body.attachments) ? sanitizeUploads(body.attachments) : [];
             const task = await this.store.createTaskFromMessage({
                 sessionId,
+                projectId: url.searchParams.get("projectId") ?? undefined,
                 text: String(body.text ?? ""),
                 route,
                 uploads
             });
             this.enqueueTask(sessionId, task.id);
-            const session = await this.store.readSession(sessionId);
+            const session = await this.store.readSession(sessionId, url.searchParams.get("projectId") ?? undefined);
             writeJson(response, 202, { ok: true, data: session });
             return;
         }
@@ -102,11 +127,18 @@ export class OperatorServer {
         });
     }
     enqueueTask(sessionId, taskId) {
-        this.queueTail = this.queueTail
+        const previous = this.sessionQueueTails.get(sessionId) ?? Promise.resolve();
+        const current = previous
             .then(() => this.runQueuedTask(sessionId, taskId))
             .catch(async (error) => {
             const message = error instanceof Error ? error.message : "Unknown queue error.";
             await this.store.markTaskFailed(sessionId, taskId, message).catch(() => undefined);
+        });
+        this.sessionQueueTails.set(sessionId, current);
+        void current.finally(() => {
+            if (this.sessionQueueTails.get(sessionId) === current) {
+                this.sessionQueueTails.delete(sessionId);
+            }
         });
     }
     async runQueuedTask(sessionId, taskId) {
@@ -115,8 +147,8 @@ export class OperatorServer {
         if (!task) {
             return;
         }
-        const paths = this.store.getSessionPaths(sessionId);
-        await this.store.markTaskRunning(sessionId, taskId);
+        const paths = await this.store.getSessionPaths(sessionId, session.projectId);
+        await this.store.markTaskRunning(sessionId, taskId, session.projectId);
         try {
             const result = await runMarshalTask({
                 task: task.prompt,
@@ -124,15 +156,16 @@ export class OperatorServer {
                 attachments: task.attachments,
                 workspaceRoot: paths.workspaceDir,
                 memoryDir: paths.memoryDir,
+                chatProjectName: session.projectId === "legacy-chats" ? undefined : session.projectName,
                 onEvent: async (event) => {
-                    await this.store.appendTaskEvent(sessionId, taskId, event.type, formatRuntimeEvent(event));
+                    await this.store.appendTaskEvent(sessionId, taskId, event.type, formatRuntimeEvent(event), session.projectId);
                 }
             });
-            await this.store.markTaskCompleted(sessionId, taskId, result);
+            await this.store.markTaskCompleted(sessionId, taskId, result, session.projectId);
         }
         catch (error) {
             const message = error instanceof Error ? error.message : "Unknown task failure.";
-            await this.store.markTaskFailed(sessionId, taskId, message);
+            await this.store.markTaskFailed(sessionId, taskId, message, session.projectId);
         }
     }
     async serveStatic(requestPath, response) {
@@ -148,6 +181,26 @@ export class OperatorServer {
             "cache-control": "no-store"
         });
         response.end(content);
+    }
+    async resumePendingTasks() {
+        const sessions = await this.store.listSessions();
+        for (const sessionSummary of sessions) {
+            const session = await this.store.readSession(sessionSummary.id).catch(() => null);
+            if (!session) {
+                continue;
+            }
+            for (const task of session.tasks) {
+                if (task.status === "queued") {
+                    this.enqueueTask(session.id, task.id);
+                    continue;
+                }
+                if (task.status === "running") {
+                    await this.store
+                        .markTaskFailed(session.id, task.id, "Operator server restarted before task completion.", session.projectId)
+                        .catch(() => undefined);
+                }
+            }
+        }
     }
 }
 function normalizeRoute(value) {

--- a/dist/operator/session-store.js
+++ b/dist/operator/session-store.js
@@ -1,44 +1,80 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { getDefaultSessionMemory, getDefaultSessionWorkspace } from "../agent/runtime/marshal.js";
+const DEFAULT_PROJECT_NAME = (process.env.OPERATOR_DEFAULT_PROJECT_NAME ?? "Andrii").trim() || "Andrii";
+const LEGACY_PROJECT_ID = "legacy-chats";
+const LEGACY_PROJECT_NAME = "Imported chats";
+const SESSION_FILE_NAME = "session.json";
+const PROJECT_FILE_NAME = "project.json";
 export class OperatorSessionStore {
-    baseDir;
+    rootDir;
+    projectsDir;
+    legacySessionsDir;
     sessionLocks = new Map();
-    constructor(baseDir = path.resolve(process.cwd(), "operator-data", "sessions")) {
-        this.baseDir = baseDir;
+    constructor(rootDir = path.resolve(process.cwd(), "operator-data")) {
+        this.rootDir = rootDir;
+        this.projectsDir = path.join(rootDir, "projects");
+        this.legacySessionsDir = path.join(rootDir, "sessions");
     }
     async initialize() {
-        await fs.mkdir(this.baseDir, { recursive: true });
+        await fs.mkdir(this.rootDir, { recursive: true });
+        await fs.mkdir(this.projectsDir, { recursive: true });
+        await this.ensureProject({ name: DEFAULT_PROJECT_NAME });
     }
-    async listSessions() {
+    async listProjects() {
         await this.initialize();
-        const dirents = await fs.readdir(this.baseDir, { withFileTypes: true });
-        const sessions = await Promise.all(dirents
-            .filter((entry) => entry.isDirectory())
-            .map(async (entry) => this.readSession(entry.name).catch(() => null)));
+        const projects = await this.readProjectRecords();
+        const summaries = await Promise.all(projects.map(async (project) => ({
+            id: project.id,
+            name: project.name,
+            createdAt: project.createdAt,
+            sessionCount: await this.countProjectSessions(project),
+            isDefault: project.name === DEFAULT_PROJECT_NAME,
+            isLegacy: project.isLegacy
+        })));
+        return summaries.sort((left, right) => {
+            if (left.isDefault !== right.isDefault) {
+                return left.isDefault ? -1 : 1;
+            }
+            if (left.isLegacy !== right.isLegacy) {
+                return left.isLegacy ? 1 : -1;
+            }
+            if (right.sessionCount !== left.sessionCount) {
+                return right.sessionCount - left.sessionCount;
+            }
+            return left.name.localeCompare(right.name);
+        });
+    }
+    async createProject(name) {
+        const project = await this.ensureProject({ name });
+        return {
+            id: project.id,
+            name: project.name,
+            createdAt: project.createdAt,
+            sessionCount: await this.countProjectSessions(project),
+            isDefault: project.name === DEFAULT_PROJECT_NAME,
+            isLegacy: project.isLegacy
+        };
+    }
+    async listSessions(projectId) {
+        await this.initialize();
+        const projects = projectId
+            ? [await this.resolveProject(projectId)]
+            : await this.readProjectRecords();
+        const sessions = await Promise.all(projects.map(async (project) => this.listSessionsForProject(project)));
         return sessions
-            .filter((session) => session !== null)
-            .map((session) => {
-            const activeTask = session.tasks.find((task) => task.id === session.activeTaskId) ?? null;
-            return {
-                id: session.id,
-                title: session.title,
-                createdAt: session.createdAt,
-                updatedAt: session.updatedAt,
-                activeTaskId: session.activeTaskId,
-                activeTaskStatus: activeTask?.status ?? null,
-                messageCount: session.messages.length
-            };
-        })
+            .flat()
             .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
     }
-    async createSession(title) {
+    async createSession(title, projectId) {
         await this.initialize();
+        const project = await this.resolveProject(projectId);
         const id = randomUUID();
         const now = new Date().toISOString();
         const session = {
             id,
+            projectId: project.id,
+            projectName: project.name,
             title: title?.trim() || "New operator session",
             createdAt: now,
             updatedAt: now,
@@ -56,16 +92,26 @@ export class OperatorSessionStore {
             ],
             tasks: []
         };
-        const paths = this.getSessionPaths(id);
+        const paths = this.getPathsForProject(project, id);
         await fs.mkdir(paths.dir, { recursive: true });
         await fs.mkdir(paths.workspaceDir, { recursive: true });
         await fs.mkdir(paths.memoryDir, { recursive: true });
         await this.writeSession(session);
         return session;
     }
-    async readSession(sessionId) {
-        const raw = await fs.readFile(this.getSessionPaths(sessionId).filePath, "utf8");
-        return JSON.parse(raw);
+    async readSession(sessionId, projectId) {
+        const located = await this.locateSession(sessionId, projectId);
+        const raw = await fs.readFile(located.paths.filePath, "utf8");
+        return normalizeSession(JSON.parse(raw), located.project);
+    }
+    async deleteSession(sessionId, projectId) {
+        const session = await this.readSession(sessionId, projectId);
+        const activeTask = session.tasks.find((task) => task.status === "queued" || task.status === "running");
+        if (activeTask) {
+            throw new Error("Cannot delete a chat while a task is queued or running.");
+        }
+        const paths = await this.getSessionPaths(sessionId, projectId);
+        await fs.rm(paths.dir, { recursive: true, force: true });
     }
     async createTaskFromMessage(input) {
         const trimmedText = input.text.trim();
@@ -73,8 +119,8 @@ export class OperatorSessionStore {
             throw new Error("Task text is required.");
         }
         return this.withSessionLock(input.sessionId, async () => {
-            const session = await this.readSession(input.sessionId);
-            const attachments = await this.saveUploads(input.sessionId, input.uploads);
+            const session = await this.readSession(input.sessionId, input.projectId);
+            const attachments = await this.saveUploads(input.sessionId, session.projectId, input.uploads);
             const now = new Date().toISOString();
             const taskId = randomUUID();
             const task = {
@@ -117,8 +163,8 @@ export class OperatorSessionStore {
             return task;
         });
     }
-    async markTaskRunning(sessionId, taskId) {
-        await this.mutateSession(sessionId, (session) => {
+    async markTaskRunning(sessionId, taskId, projectId) {
+        await this.mutateSession(sessionId, projectId, (session) => {
             const task = findTask(session, taskId);
             const now = new Date().toISOString();
             task.status = "running";
@@ -133,8 +179,8 @@ export class OperatorSessionStore {
             session.updatedAt = now;
         });
     }
-    async appendTaskEvent(sessionId, taskId, type, detail) {
-        await this.mutateSession(sessionId, (session) => {
+    async appendTaskEvent(sessionId, taskId, type, detail, projectId) {
+        await this.mutateSession(sessionId, projectId, (session) => {
             const task = findTask(session, taskId);
             const now = new Date().toISOString();
             task.events.push({
@@ -146,8 +192,8 @@ export class OperatorSessionStore {
             session.updatedAt = now;
         });
     }
-    async markTaskCompleted(sessionId, taskId, result) {
-        await this.mutateSession(sessionId, (session) => {
+    async markTaskCompleted(sessionId, taskId, result, projectId) {
+        await this.mutateSession(sessionId, projectId, (session) => {
             const task = findTask(session, taskId);
             const now = new Date().toISOString();
             task.status = "completed";
@@ -172,8 +218,8 @@ export class OperatorSessionStore {
             session.updatedAt = now;
         });
     }
-    async markTaskFailed(sessionId, taskId, error) {
-        await this.mutateSession(sessionId, (session) => {
+    async markTaskFailed(sessionId, taskId, error, projectId) {
+        await this.mutateSession(sessionId, projectId, (session) => {
             const task = findTask(session, taskId);
             const now = new Date().toISOString();
             task.status = "failed";
@@ -198,21 +244,156 @@ export class OperatorSessionStore {
             session.updatedAt = now;
         });
     }
-    getSessionPaths(sessionId) {
-        const dir = path.join(this.baseDir, sessionId);
+    async getSessionPaths(sessionId, projectId) {
+        const located = await this.locateSession(sessionId, projectId);
+        return located.paths;
+    }
+    async listSessionsForProject(project) {
+        await fs.mkdir(project.sessionsDir, { recursive: true });
+        const dirents = await fs.readdir(project.sessionsDir, { withFileTypes: true });
+        const sessions = await Promise.all(dirents
+            .filter((entry) => entry.isDirectory())
+            .map(async (entry) => this.readSession(entry.name, project.id).catch(() => null)));
+        return sessions
+            .filter((session) => session !== null)
+            .map((session) => {
+            const activeTask = session.tasks.find((task) => task.id === session.activeTaskId) ?? null;
+            return {
+                id: session.id,
+                projectId: session.projectId,
+                projectName: session.projectName,
+                title: session.title,
+                createdAt: session.createdAt,
+                updatedAt: session.updatedAt,
+                activeTaskId: session.activeTaskId,
+                activeTaskStatus: activeTask?.status ?? null,
+                messageCount: session.messages.length
+            };
+        });
+    }
+    async readProjectRecords() {
+        const projects = [];
+        const dirents = await fs.readdir(this.projectsDir, { withFileTypes: true }).catch(() => []);
+        for (const entry of dirents) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            const dir = path.join(this.projectsDir, entry.name);
+            const projectFilePath = path.join(dir, PROJECT_FILE_NAME);
+            const raw = await fs.readFile(projectFilePath, "utf8").catch(() => null);
+            if (!raw) {
+                continue;
+            }
+            const parsed = JSON.parse(raw);
+            const id = typeof parsed.id === "string" && parsed.id.trim() ? parsed.id : entry.name;
+            const name = typeof parsed.name === "string" && parsed.name.trim() ? parsed.name : entry.name;
+            const createdAt = typeof parsed.createdAt === "string" && parsed.createdAt.trim()
+                ? parsed.createdAt
+                : new Date().toISOString();
+            projects.push({
+                id,
+                name,
+                createdAt,
+                dir,
+                sessionsDir: path.join(dir, "sessions"),
+                isLegacy: false
+            });
+        }
+        const legacyExists = await hasDirectory(this.legacySessionsDir);
+        if (legacyExists) {
+            const legacyCount = await countDirectories(this.legacySessionsDir);
+            if (legacyCount > 0) {
+                projects.push({
+                    id: LEGACY_PROJECT_ID,
+                    name: LEGACY_PROJECT_NAME,
+                    createdAt: new Date(0).toISOString(),
+                    dir: this.legacySessionsDir,
+                    sessionsDir: this.legacySessionsDir,
+                    isLegacy: true
+                });
+            }
+        }
+        return projects;
+    }
+    async ensureProject(input) {
+        await fs.mkdir(this.projectsDir, { recursive: true });
+        const requestedId = input.id?.trim();
+        const requestedName = input.name?.trim() || DEFAULT_PROJECT_NAME;
+        const existing = await this.readProjectRecords();
+        if (requestedId) {
+            const matchedById = existing.find((project) => project.id === requestedId);
+            if (matchedById) {
+                return matchedById;
+            }
+        }
+        const matchedByName = existing.find((project) => !project.isLegacy && project.name.toLowerCase() === requestedName.toLowerCase());
+        if (matchedByName) {
+            return matchedByName;
+        }
+        const existingIds = new Set(existing.map((project) => project.id));
+        const baseId = slugifyProjectId(requestedId || requestedName);
+        let projectId = baseId;
+        let suffix = 2;
+        while (existingIds.has(projectId)) {
+            projectId = `${baseId}-${suffix}`;
+            suffix += 1;
+        }
+        const createdAt = new Date().toISOString();
+        const dir = path.join(this.projectsDir, projectId);
+        const project = {
+            id: projectId,
+            name: requestedName,
+            createdAt,
+            dir,
+            sessionsDir: path.join(dir, "sessions"),
+            isLegacy: false
+        };
+        await fs.mkdir(project.sessionsDir, { recursive: true });
+        await fs.writeFile(path.join(project.dir, PROJECT_FILE_NAME), JSON.stringify({
+            id: project.id,
+            name: project.name,
+            createdAt: project.createdAt
+        }, null, 2) + "\n", "utf8");
+        return project;
+    }
+    async resolveProject(projectId) {
+        if (!projectId) {
+            return this.ensureProject({ name: DEFAULT_PROJECT_NAME });
+        }
+        const projects = await this.readProjectRecords();
+        const matched = projects.find((project) => project.id === projectId);
+        if (matched) {
+            return matched;
+        }
+        throw new Error(`Project not found: ${projectId}`);
+    }
+    async locateSession(sessionId, projectId) {
+        const projects = projectId
+            ? [await this.resolveProject(projectId)]
+            : await this.readProjectRecords();
+        for (const project of projects) {
+            const paths = this.getPathsForProject(project, sessionId);
+            if (await hasFile(paths.filePath)) {
+                return { project, paths };
+            }
+        }
+        throw new Error(`Session not found: ${sessionId}`);
+    }
+    getPathsForProject(project, sessionId) {
+        const dir = path.join(project.sessionsDir, sessionId);
         return {
             dir,
-            filePath: path.join(dir, "session.json"),
-            workspaceDir: getDefaultSessionWorkspace(sessionId),
-            memoryDir: getDefaultSessionMemory(sessionId),
-            uploadsDir: path.join(getDefaultSessionWorkspace(sessionId), "uploads")
+            filePath: path.join(dir, SESSION_FILE_NAME),
+            workspaceDir: path.join(dir, "workspace"),
+            memoryDir: path.join(dir, "memory"),
+            uploadsDir: path.join(dir, "workspace", "uploads")
         };
     }
-    async saveUploads(sessionId, uploads) {
+    async saveUploads(sessionId, projectId, uploads) {
         if (uploads.length === 0) {
             return [];
         }
-        const paths = this.getSessionPaths(sessionId);
+        const paths = await this.getSessionPaths(sessionId, projectId);
         await fs.mkdir(paths.uploadsDir, { recursive: true });
         return Promise.all(uploads.map(async (upload) => {
             const attachmentId = randomUUID();
@@ -232,19 +413,23 @@ export class OperatorSessionStore {
             };
         }));
     }
-    async mutateSession(sessionId, mutate) {
+    async mutateSession(sessionId, projectId, mutate) {
         await this.withSessionLock(sessionId, async () => {
-            const session = await this.readSession(sessionId);
+            const session = await this.readSession(sessionId, projectId);
             mutate(session);
             await this.writeSession(session);
         });
     }
     async writeSession(session) {
-        const paths = this.getSessionPaths(session.id);
+        const project = await this.resolveProject(session.projectId);
+        const paths = this.getPathsForProject(project, session.id);
         await fs.mkdir(paths.dir, { recursive: true });
         const tmpPath = `${paths.filePath}.tmp`;
         await fs.writeFile(tmpPath, JSON.stringify(session, null, 2) + "\n", "utf8");
         await fs.rename(tmpPath, paths.filePath);
+    }
+    async countProjectSessions(project) {
+        return countDirectories(project.sessionsDir);
     }
     async withSessionLock(sessionId, operation) {
         const previous = this.sessionLocks.get(sessionId) ?? Promise.resolve();
@@ -268,6 +453,41 @@ function findTask(session, taskId) {
     }
     return task;
 }
-function sanitizeFilename(fileName) {
-    return fileName.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "") || "upload.bin";
+function sanitizeFilename(input) {
+    return input.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "upload.bin";
+}
+function slugifyProjectId(input) {
+    const slug = input
+        .normalize("NFKD")
+        .replace(/[^\w\s-]/g, "")
+        .trim()
+        .toLowerCase()
+        .replace(/[\s_-]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+    return slug || "project";
+}
+function normalizeSession(raw, project) {
+    return {
+        id: String(raw.id ?? ""),
+        projectId: typeof raw.projectId === "string" && raw.projectId.trim() ? raw.projectId : project.id,
+        projectName: typeof raw.projectName === "string" && raw.projectName.trim() ? raw.projectName : project.name,
+        title: typeof raw.title === "string" && raw.title.trim() ? raw.title : "Untitled session",
+        createdAt: typeof raw.createdAt === "string" ? raw.createdAt : new Date().toISOString(),
+        updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date().toISOString(),
+        activeTaskId: typeof raw.activeTaskId === "string" ? raw.activeTaskId : null,
+        messages: Array.isArray(raw.messages) ? raw.messages : [],
+        tasks: Array.isArray(raw.tasks) ? raw.tasks : []
+    };
+}
+async function hasDirectory(targetPath) {
+    const stat = await fs.stat(targetPath).catch(() => null);
+    return Boolean(stat?.isDirectory());
+}
+async function hasFile(targetPath) {
+    const stat = await fs.stat(targetPath).catch(() => null);
+    return Boolean(stat?.isFile());
+}
+async function countDirectories(targetPath) {
+    const dirents = await fs.readdir(targetPath, { withFileTypes: true }).catch(() => []);
+    return dirents.filter((entry) => entry.isDirectory()).length;
 }

--- a/docs/CHATGPT_EXTENSION_SETUP.md
+++ b/docs/CHATGPT_EXTENSION_SETUP.md
@@ -57,7 +57,11 @@ If the CLI keeps waiting:
 - refresh the ChatGPT tab
 - keep the ChatGPT tab focused long enough for the first bridge handshake
 
-If Chrome is already running, the launcher will stop and ask you to close it first. This is required to attach remote debugging to the real `Andrii` profile. If you want the script to quit Chrome automatically, set:
+If the Marshal-managed `Andrii` Chrome session is already running, the launcher will reuse it and open ChatGPT there again.
+
+If another Chrome session is already using the same Chrome app and user-data directory, the launcher will stop instead of quitting the whole app. This avoids closing unrelated Chrome profiles.
+
+The old global auto-quit behavior is intentionally disabled for safety. `CHATGPT_AUTO_QUIT_CHROME=1` no longer force-quits all of Chrome:
 
 ```sh
 CHATGPT_AUTO_QUIT_CHROME=1

--- a/docs/MENUBAR_APP_PLAN.md
+++ b/docs/MENUBAR_APP_PLAN.md
@@ -1,0 +1,514 @@
+# Marshal macOS Menu Bar App Plan
+
+## Status
+
+- Created: `2026-03-19`
+- Scope: design and implementation roadmap
+- Target: a macOS menu bar app that wraps Marshal without rewriting the agent runtime
+
+## Why This Exists
+
+The current operator surface is a local web console opened in Chrome at `http://127.0.0.1:3489`. That works for development, but it has product-level friction:
+
+- it depends on a visible browser tab for operator control
+- it splits state across the browser window, the Chrome ChatGPT tab, and shell scripts
+- it does not feel like a native desktop utility
+- it makes lifecycle operations like start, restart, health, and bridge status harder to reason about
+
+The menu bar app should become the primary operator surface on macOS while keeping the existing Marshal runtime, task orchestration, and ChatGPT bridge logic.
+
+## Current Architecture Summary
+
+The good news is that most of the hard backend pieces already exist and should be reused:
+
+- The agent execution boundary is already centralized in [`agent/runtime/marshal.ts`](../agent/runtime/marshal.ts).
+- Session persistence, per-session workspaces, uploads, and task history already live in [`operator/session-store.ts`](../operator/session-store.ts).
+- The operator server already exposes a small local API in [`operator/server.ts`](../operator/server.ts).
+- The ChatGPT connection is already abstracted behind a bridge factory in [`agent/bridge/factory.ts`](../agent/bridge/factory.ts).
+- The extension bridge already runs through a localhost bridge server in [`agent/bridge/local-bridge-server.ts`](../agent/bridge/local-bridge-server.ts).
+
+The current weakest seam is that operator orchestration is still coupled to the HTTP server:
+
+- task queueing, session mutation, and runtime event flattening are mixed into `OperatorServer`
+- the web UI only sees stringified events rather than structured runtime events
+- file ingress is web-shaped because uploads are converted to base64 in the browser client
+
+## Research Summary
+
+### Option A: Electron menu bar shell
+
+Fit with this repo:
+
+- Strongest fit for v1.
+- The project is already Node.js + TypeScript.
+- Electron already has a main process, renderer processes, tray APIs, hidden-accessory app mode, and a Node-capable utility process.
+- We can reuse existing TypeScript runtime code directly instead of introducing Rust or Swift for core orchestration.
+
+What Electron gives us:
+
+- A tray/menu bar entry point via `Tray`.
+- A Dock-less app mode on macOS via `app.setActivationPolicy('accessory')`.
+- A separate Node-capable child process via `utilityProcess.fork(...)` for isolating Marshal backend work from the desktop shell UI.
+- A normal renderer window for a compact native-feeling operator panel.
+
+Tradeoffs:
+
+- Larger bundle size than Tauri or native Swift.
+- We must be strict about preload + IPC boundaries and not expose Node primitives directly to the renderer.
+
+Assessment:
+
+- Best choice for v1 because it preserves implementation speed and reuse.
+
+### Option B: Tauri menu bar shell with Node sidecar
+
+Fit with this repo:
+
+- Technically viable, but a worse v1 fit.
+- Tauri tray support is solid and Tauri documents both tray handling and Node.js sidecars.
+- However, it introduces a Rust shell plus sidecar packaging, target-triple binary management, shell permissions, and a second app architecture around the current Node runtime.
+
+Tradeoffs:
+
+- Smaller app footprint than Electron.
+- Better native feel than Electron by default.
+- Higher integration cost for this codebase right now.
+- More packaging complexity because Marshal would still live as a bundled sidecar binary or embedded Node runtime.
+
+Assessment:
+
+- Good candidate for a later optimization pass, not the first production menu bar implementation.
+
+### Option C: Native SwiftUI/AppKit menu bar app
+
+Fit with this repo:
+
+- Best macOS-native UX on paper.
+- Worst near-term fit for this codebase.
+- Apple’s `MenuBarExtra` is a clean native path for a menu bar utility, but we would still need to host or supervise the existing Marshal Node runtime somehow.
+
+Tradeoffs:
+
+- Strongest native platform integration.
+- Highest implementation cost and the largest architecture split.
+- Would force us to maintain a native shell and a separate JS runtime stack from day one.
+
+Assessment:
+
+- Long-term possibility only if Marshal becomes a macOS-only product and native polish matters more than shipping speed.
+
+## Recommended Direction
+
+Build **v1 as an Electron menu bar app** on top of the current project.
+
+More specifically:
+
+1. Keep the existing agent runtime, ChatGPT bridge, and session store.
+2. Extract operator orchestration out of `OperatorServer` into a transport-neutral service layer.
+3. Add an Electron shell that:
+   - owns app lifecycle
+   - owns menu bar / tray UI
+   - launches a compact renderer panel
+   - hosts Marshal backend work in a separate Electron utility process
+4. Keep the current web operator console as a development fallback until the native shell reaches parity.
+
+This gives the best balance of:
+
+- speed to first usable app
+- reuse of existing Node/TS code
+- safer runtime isolation than “everything in Electron main”
+- a clean path to packaging, autostart, and future desktop polish
+
+## Target Architecture
+
+### Layer 1: Core Marshal runtime
+
+Keep and reuse:
+
+- `runMarshalTask`
+- `FileSandbox`
+- `ShellTool`
+- `BrowserTool`
+- `AgentLoop`
+- ChatGPT bridge implementations
+- `MemoryStore`
+
+No menu bar code belongs here.
+
+### Layer 2: Operator domain service
+
+Create a new transport-neutral service module, tentatively:
+
+- `operator/task-service.ts`
+- `operator/event-bus.ts`
+
+Responsibilities:
+
+- create/list/delete projects and sessions
+- submit tasks
+- manage per-session queueing
+- resume queued tasks after restart
+- expose structured task/runtime events
+- mediate attachments and workspace initialization
+
+This layer should depend on:
+
+- `OperatorSessionStore`
+- `runMarshalTask`
+
+This layer should not depend on:
+
+- HTTP request/response objects
+- browser DOM
+- Electron APIs
+
+### Layer 3: Transport adapters
+
+Two adapters should sit on top of the operator domain service:
+
+- `OperatorServer` as the existing localhost HTTP adapter
+- Electron IPC adapter for the menu bar app
+
+This is the key refactor that prevents us from hard-coding the desktop app to the current web server shape.
+
+### Layer 4: Electron shell
+
+Proposed structure:
+
+- `desktop/main.ts`
+- `desktop/preload.ts`
+- `desktop/renderer/*`
+- `desktop/backend.ts` or `desktop/utility/*`
+
+Responsibilities:
+
+- create tray/menu bar icon
+- set macOS accessory activation policy
+- open/close/toggle a compact operator window
+- show health/state in menu items
+- launch backend utility process
+- bridge renderer IPC to backend commands
+- surface notifications and errors
+
+### Layer 5: Chrome/ChatGPT control surface
+
+Do not replace this in v1.
+
+Keep:
+
+- the Chrome profile launcher
+- the extension bridge
+- the real ChatGPT tab workflow
+
+But move control into the desktop shell:
+
+- “Open ChatGPT”
+- “Reconnect Bridge”
+- “Restart Marshal”
+- “Open Execution Log”
+- “Open Session Workspace”
+
+## Product Scope For v1
+
+The first menu bar release should support:
+
+- tray icon with running/waiting/error states
+- compact panel window with:
+  - project selector
+  - session list
+  - message history
+  - task composer
+  - route selector
+  - execution log
+- native file attachment picker
+- native workspace folder selection for a session or project
+- explicit Chrome/bridge status
+- buttons to open ChatGPT, restart backend, and inspect session files
+- persistent history using the existing session store
+
+v1 should not try to solve:
+
+- Telegram integration
+- multi-user sync
+- cloud sync
+- App Store sandboxing
+- replacing the ChatGPT bridge with a fully native OpenAI API mode
+
+## Key Design Decisions
+
+### 1. Backend isolation
+
+Recommendation:
+
+- Run Marshal backend logic in an Electron utility process, not in the Electron main process.
+
+Why:
+
+- task execution, Playwright usage, and browser bridge work are more failure-prone than menu UI code
+- utility process boundaries reduce the chance that runtime failures kill the menu bar shell
+- Electron explicitly positions utility processes as Node-capable child processes for crash-prone or heavy components
+
+### 2. Keep structured runtime events
+
+Current issue:
+
+- `OperatorServer` flattens runtime events into strings before persistence and UI rendering
+
+Recommendation:
+
+- persist both:
+  - structured event payload
+  - human-readable message
+
+Why:
+
+- native UI needs more than text blobs
+- progress indicators, status badges, filters, and diagnostics should key off structured data
+
+### 3. Native file/workspace selection
+
+Current issue:
+
+- filesystem writes are sandboxed per session workspace, but the UI still invites the user to think in arbitrary absolute paths
+
+Recommendation:
+
+- make workspace selection explicit in the native app
+- let the menu bar app choose:
+  - default project workspace
+  - session workspace override
+  - “import file into workspace” flow
+
+This is the right fix for the earlier `/Users/.../temp` confusion.
+
+### 4. Keep the web console during migration
+
+Recommendation:
+
+- do not delete `operator/static/*` in the first desktop milestone
+
+Why:
+
+- it remains useful as a developer console and fallback surface
+- it reduces migration risk
+- it gives us parity targets for the menu bar UI
+
+## Proposed Phases
+
+### Phase A. Operator service extraction
+
+Goal:
+
+- split transport-neutral orchestration from `OperatorServer`
+
+Deliverables:
+
+- `OperatorTaskService`
+- reusable queue management
+- reusable task execution lifecycle
+- reusable structured event emission
+
+Done when:
+
+- the HTTP server becomes a thin adapter over the service
+- no core orchestration logic lives only in the server layer
+
+### Phase B. Event model hardening
+
+Goal:
+
+- preserve structured runtime events end-to-end
+
+Deliverables:
+
+- typed event payloads persisted to session data
+- human-readable event formatting as a presentation concern
+- clear statuses for bridge disconnected / bridge ready / task queued / task running / task failed
+
+Done when:
+
+- desktop UI can render progress without string parsing
+
+### Phase C. Electron shell scaffold
+
+Goal:
+
+- add an Electron desktop shell without changing existing Marshal behavior
+
+Deliverables:
+
+- `desktop/` app scaffold
+- tray icon
+- accessory activation policy on macOS
+- toggleable compact window
+- renderer + preload + IPC skeleton
+
+Done when:
+
+- app launches from the menu bar and can show a placeholder panel
+
+### Phase D. Backend utility process
+
+Goal:
+
+- isolate backend/runtime work from desktop shell UI
+
+Deliverables:
+
+- Electron utility process entrypoint
+- IPC command channel for:
+  - health
+  - projects
+  - sessions
+  - submit task
+  - cancel/restart backend
+- stdout/stderr capture for diagnostics
+
+Done when:
+
+- closing and reopening the panel does not affect the backend
+- backend crashes can be surfaced and recovered without killing the shell
+
+### Phase E. Native operator panel
+
+Goal:
+
+- replace the browser-hosted operator UI with an Electron renderer panel
+
+Deliverables:
+
+- project selector
+- session list
+- message list
+- task composer
+- route selector
+- event log
+- task state badges
+
+Done when:
+
+- core operator flow is possible entirely inside the app
+
+### Phase F. Native attachments and workspace controls
+
+Goal:
+
+- remove browser-only attachment assumptions and make workspace behavior explicit
+
+Deliverables:
+
+- file picker integration
+- “open workspace” action
+- configurable project/session workspace root
+- UI copy that explains filesystem limits clearly
+
+Done when:
+
+- file tasks are understandable and repeatable from the native app
+
+### Phase G. Chrome and bridge lifecycle controls
+
+Goal:
+
+- make ChatGPT/bridge state operable from the menu bar app
+
+Deliverables:
+
+- status row for:
+  - Chrome profile session
+  - extension bridge health
+  - current ChatGPT project
+- actions:
+  - open ChatGPT
+  - reconnect bridge
+  - restart Marshal backend
+  - open latest session logs
+
+Done when:
+
+- the desktop app becomes the control plane for the existing ChatGPT workflow
+
+### Phase H. Packaging and startup
+
+Goal:
+
+- make the app installable and usable as a background utility
+
+Deliverables:
+
+- packaged macOS app
+- code signing plan
+- tray icon assets
+- launch at login support
+- single-instance behavior
+
+Done when:
+
+- the app can be started from Applications and optionally from login items
+
+## Risks And Mitigations
+
+### Risk: desktop shell and backend share too much state
+
+Mitigation:
+
+- isolate backend in utility process
+- keep renderer IPC narrow
+
+### Risk: ChatGPT bridge remains the real operational bottleneck
+
+Mitigation:
+
+- treat Chrome/extension state as first-class app status
+- build reconnect and diagnostics into the tray menu and panel
+
+### Risk: filesystem UX stays confusing
+
+Mitigation:
+
+- expose workspace root explicitly
+- avoid implying arbitrary path writes are supported when sandboxed mode is active
+
+### Risk: migration drags because web and desktop UIs diverge
+
+Mitigation:
+
+- extract operator service first
+- keep the current web console as a parity harness until the native panel is proven
+
+## Acceptance Criteria
+
+The menu bar app initiative is only complete when all of the following are true:
+
+1. Marshal can be controlled without opening the browser-hosted operator console.
+2. The app exposes current bridge/backend health at a glance from the menu bar.
+3. A user can create a session, submit a task, attach files, and inspect progress from the panel.
+4. Session history persists across restarts.
+5. The app explains workspace limits clearly enough that file-task results are trustworthy.
+6. Backend failures are visible and recoverable from the shell UI.
+
+## Suggested Implementation Order
+
+Build in this order:
+
+1. Extract operator service from HTTP server.
+2. Preserve structured runtime events.
+3. Add Electron shell and utility process.
+4. Build a compact renderer panel for sessions/tasks.
+5. Add file picker and workspace controls.
+6. Add Chrome/bridge lifecycle controls.
+7. Package and sign the app.
+
+## Sources
+
+- Apple SwiftUI `MenuBarExtra`: [developer.apple.com/documentation/swiftui/menubarextra](https://developer.apple.com/documentation/swiftui/menubarextra)
+- Apple WWDC22 `Bring multiple windows to your SwiftUI app`: [developer.apple.com/videos/play/wwdc2022/10061](https://developer.apple.com/videos/play/wwdc2022/10061/)
+- Electron process model: [electronjs.org/docs/latest/tutorial/process-model](https://www.electronjs.org/docs/latest/tutorial/process-model)
+- Electron `BrowserWindow`: [electronjs.org/docs/api/browser-window](https://www.electronjs.org/docs/api/browser-window)
+- Electron tray tutorial: [electronjs.org/docs/latest/tutorial/tray](https://www.electronjs.org/docs/latest/tutorial/tray)
+- Electron `app.setActivationPolicy`: [electronjs.org/docs/latest/api/app](https://www.electronjs.org/docs/latest/api/app/)
+- Electron `utilityProcess`: [electronjs.org/docs/latest/api/utility-process](https://www.electronjs.org/docs/latest/api/utility-process)
+- Tauri system tray: [v2.tauri.app/learn/system-tray](https://v2.tauri.app/learn/system-tray/)
+- Tauri external binaries / sidecar: [v2.tauri.app/develop/sidecar](https://v2.tauri.app/develop/sidecar/)
+- Tauri Node.js sidecar guide: [v2.tauri.app/learn/sidecar-nodejs](https://v2.tauri.app/learn/sidecar-nodejs/)
+- Tauri autostart plugin: [v2.tauri.app/plugin/autostart](https://v2.tauri.app/plugin/autostart/)

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -193,6 +193,25 @@ Checklist:
 - [ ] Add permission gates for local shell, filesystem, and live browser actions.
 - [ ] Validate cross-channel continuity between web UI and Telegram.
 
+### Phase 11. macOS Menu Bar App
+
+Goal:
+- Add a native-feeling macOS menu bar control surface on top of the existing Marshal runtime.
+
+Done when:
+- Marshal can be controlled from a menu bar app without the browser-hosted operator console.
+- The app exposes backend and ChatGPT bridge health clearly.
+- Sessions, tasks, attachments, and execution logs are usable from the menu bar UI.
+- The desktop shell owns lifecycle actions like start, restart, open ChatGPT, and open workspace/logs.
+
+Checklist:
+- [ ] Extract transport-neutral operator orchestration from the HTTP server.
+- [ ] Preserve structured runtime events for native progress UI.
+- [ ] Add a desktop shell scaffold for the menu bar app.
+- [ ] Add a native session/task panel with attachments and execution log.
+- [ ] Add Chrome and extension bridge lifecycle controls.
+- [ ] Package and validate the app on macOS.
+
 ## Current Exit Criteria
 
-The project is not complete until Phases 4, 6, 7, 8, 9, and 10 are closed with live validation, not only static implementation.
+The project is not complete until Phases 4, 6, 7, 8, 9, 10, and 11 are closed with live validation, not only static implementation.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -24,6 +24,7 @@
 - `Phase 8. Operator Web Console`
 - `Phase 9. Telegram Control Surface`
 - `Phase 10. Unified Control Plane`
+- `Phase 11. macOS Menu Bar App`
 
 ## Completed Items
 
@@ -43,6 +44,7 @@
 - A local operator web server now exists with persistent chat sessions and a static web console UI.
 - Operator tasks can include uploaded files, which are persisted into per-session workspaces.
 - Operator sessions can route tasks through `auto`, `local`, or `browser` execution modes.
+- A dedicated architecture and implementation plan now exists for the macOS menu bar app in `docs/MENUBAR_APP_PLAN.md`.
 
 ## Open Issues
 
@@ -51,6 +53,7 @@
 - Live validation of the new `Andrii` launcher flow is still required.
 - Phase 8 still needs a live UI-driven run against a connected ChatGPT session with a real file attachment.
 - Telegram and unified control-plane phases are still not implemented.
+- The macOS menu bar app is planned but not yet scaffolded or integrated.
 
 ## Phase Close Checklist
 

--- a/open-chatgpt-browser-default-profile.sh
+++ b/open-chatgpt-browser-default-profile.sh
@@ -21,6 +21,23 @@ CHATGPT_URL=${CHATGPT_URL:-https://chatgpt.com}
 AUTO_QUIT_CHROME=${CHATGPT_AUTO_QUIT_CHROME:-0}
 DRY_RUN=${CHATGPT_BROWSER_DRY_RUN:-0}
 
+find_managed_chrome_pids() {
+  ps -axo pid=,command= | awk \
+    -v chrome_bin="$CHROME_BIN" \
+    -v user_data_flag="--user-data-dir=$CHROME_USER_DATA_DIR" \
+    -v profile_flag="--profile-directory=$PROFILE_DIR" \
+    -v port_flag="--remote-debugging-port=$PORT" \
+    -v extension_flag="--load-extension=$EXTENSION_DIR" '
+      index($0, chrome_bin) &&
+      index($0, user_data_flag) &&
+      index($0, profile_flag) &&
+      index($0, port_flag) &&
+      index($0, extension_flag) {
+        print $1
+      }
+    '
+}
+
 if [ -z "$PROFILE_DIR" ]; then
   PROFILE_DIR=$(node - "$CHROME_USER_DATA_DIR" "$PROFILE_NAME" <<'NODE'
 const fs = require("fs");
@@ -96,6 +113,17 @@ NODE
   exit 1
 fi
 
+MANAGED_CHROME_PIDS=$(find_managed_chrome_pids || true)
+HAS_MANAGED_CHROME=0
+if [ -n "$MANAGED_CHROME_PIDS" ]; then
+  HAS_MANAGED_CHROME=1
+fi
+
+HAS_ANY_CHROME=0
+if osascript -e 'application "Google Chrome" is running' 2>/dev/null | grep -q "true"; then
+  HAS_ANY_CHROME=1
+fi
+
 if [ "$DRY_RUN" = "1" ]; then
   echo "Resolved profile name: $PROFILE_NAME"
   echo "Resolved profile dir: $PROFILE_DIR"
@@ -103,19 +131,27 @@ if [ "$DRY_RUN" = "1" ]; then
   echo "Extension dir: $EXTENSION_DIR"
   echo "Remote debugging port: $PORT"
   echo "ChatGPT URL: $CHATGPT_URL"
+  echo "Any Chrome running: $HAS_ANY_CHROME"
+  echo "Managed Marshal Chrome running: $HAS_MANAGED_CHROME"
+  if [ "$HAS_MANAGED_CHROME" = "1" ]; then
+    echo "Managed Marshal Chrome PIDs: $MANAGED_CHROME_PIDS"
+  fi
   exit 0
 fi
 
-if osascript -e 'application "Google Chrome" is running' 2>/dev/null | grep -q "true"; then
+if [ "$HAS_ANY_CHROME" = "1" ] && [ "$HAS_MANAGED_CHROME" != "1" ]; then
+  echo "Google Chrome is already running in another session."
+  echo "Expected profile: $PROFILE_NAME ($PROFILE_DIR)"
+  echo "Marshal will not quit the whole Chrome app automatically, because that would close other profiles too."
+  echo "Close the conflicting Chrome session first, then run this script again."
+  exit 1
+fi
+
+if [ "$HAS_MANAGED_CHROME" = "1" ]; then
+  echo "Chrome is already running with profile \"$PROFILE_NAME\" ($PROFILE_DIR)."
+  echo "Reusing the existing Marshal browser session."
   if [ "$AUTO_QUIT_CHROME" = "1" ]; then
-    osascript -e 'tell application "Google Chrome" to quit'
-    sleep 2
-  else
-    echo "Google Chrome is currently running."
-    echo "Close Chrome first, then run this script again."
-    echo "Expected profile: $PROFILE_NAME ($PROFILE_DIR)"
-    echo "If you want the script to quit Chrome automatically, set CHATGPT_AUTO_QUIT_CHROME=1."
-    exit 1
+    echo "CHATGPT_AUTO_QUIT_CHROME is ignored for unrelated Chrome profiles."
   fi
 fi
 

--- a/operator/server.ts
+++ b/operator/server.ts
@@ -14,7 +14,7 @@ export class OperatorServer {
   port: number;
   store: OperatorSessionStore;
   server: http.Server | null = null;
-  private queueTail = Promise.resolve();
+  private sessionQueueTails = new Map<string, Promise<void>>();
 
   constructor(port = Number(process.env.OPERATOR_WEB_PORT ?? "3489"), store = new OperatorSessionStore()) {
     this.port = port;
@@ -40,6 +40,8 @@ export class OperatorServer {
       this.server?.listen(this.port, "127.0.0.1", () => resolve());
       this.server?.once("error", reject);
     });
+
+    await this.resumePendingTasks();
   }
 
   async close(): Promise<void> {
@@ -57,33 +59,62 @@ export class OperatorServer {
     const url = new URL(request.url ?? "/", `http://127.0.0.1:${this.port}`);
 
     if (request.method === "GET" && url.pathname === "/api/health") {
+      const sessions = await this.store.listSessions();
+      const projects = await this.store.listProjects();
+      const queuedTasks = sessions.filter((session) => session.activeTaskStatus === "queued").length;
+      const runningTasks = sessions.filter((session) => session.activeTaskStatus === "running").length;
       writeJson(response, 200, {
         ok: true,
         data: {
           port: this.port,
-          queued: true
+          projectCount: projects.length,
+          sessionCount: sessions.length,
+          queuedTasks,
+          runningTasks
         }
       });
       return;
     }
 
+    if (request.method === "GET" && url.pathname === "/api/projects") {
+      const projects = await this.store.listProjects();
+      writeJson(response, 200, { ok: true, data: projects });
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/api/projects") {
+      const body = await readJsonBody(request);
+      const project = await this.store.createProject(typeof body.name === "string" ? body.name : undefined);
+      writeJson(response, 201, { ok: true, data: project });
+      return;
+    }
+
     if (request.method === "GET" && url.pathname === "/api/sessions") {
-      const sessions = await this.store.listSessions();
+      const sessions = await this.store.listSessions(url.searchParams.get("projectId") ?? undefined);
       writeJson(response, 200, { ok: true, data: sessions });
       return;
     }
 
     if (request.method === "POST" && url.pathname === "/api/sessions") {
       const body = await readJsonBody(request);
-      const session = await this.store.createSession(typeof body.title === "string" ? body.title : undefined);
+      const session = await this.store.createSession(
+        typeof body.title === "string" ? body.title : undefined,
+        typeof body.projectId === "string" ? body.projectId : undefined
+      );
       writeJson(response, 201, { ok: true, data: session });
       return;
     }
 
     const sessionMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)$/);
     if (request.method === "GET" && sessionMatch) {
-      const session = await this.store.readSession(sessionMatch[1]);
+      const session = await this.store.readSession(sessionMatch[1], url.searchParams.get("projectId") ?? undefined);
       writeJson(response, 200, { ok: true, data: session });
+      return;
+    }
+
+    if (request.method === "DELETE" && sessionMatch) {
+      await this.store.deleteSession(sessionMatch[1], url.searchParams.get("projectId") ?? undefined);
+      writeJson(response, 200, { ok: true });
       return;
     }
 
@@ -95,12 +126,13 @@ export class OperatorServer {
       const uploads = Array.isArray(body.attachments) ? sanitizeUploads(body.attachments) : [];
       const task = await this.store.createTaskFromMessage({
         sessionId,
+        projectId: url.searchParams.get("projectId") ?? undefined,
         text: String(body.text ?? ""),
         route,
         uploads
       });
       this.enqueueTask(sessionId, task.id);
-      const session = await this.store.readSession(sessionId);
+      const session = await this.store.readSession(sessionId, url.searchParams.get("projectId") ?? undefined);
       writeJson(response, 202, { ok: true, data: session });
       return;
     }
@@ -123,12 +155,20 @@ export class OperatorServer {
   }
 
   private enqueueTask(sessionId: string, taskId: string): void {
-    this.queueTail = this.queueTail
+    const previous = this.sessionQueueTails.get(sessionId) ?? Promise.resolve();
+    const current = previous
       .then(() => this.runQueuedTask(sessionId, taskId))
       .catch(async (error) => {
         const message = error instanceof Error ? error.message : "Unknown queue error.";
         await this.store.markTaskFailed(sessionId, taskId, message).catch(() => undefined);
       });
+
+    this.sessionQueueTails.set(sessionId, current);
+    void current.finally(() => {
+      if (this.sessionQueueTails.get(sessionId) === current) {
+        this.sessionQueueTails.delete(sessionId);
+      }
+    });
   }
 
   private async runQueuedTask(sessionId: string, taskId: string): Promise<void> {
@@ -138,8 +178,8 @@ export class OperatorServer {
       return;
     }
 
-    const paths = this.store.getSessionPaths(sessionId);
-    await this.store.markTaskRunning(sessionId, taskId);
+    const paths = await this.store.getSessionPaths(sessionId, session.projectId);
+    await this.store.markTaskRunning(sessionId, taskId, session.projectId);
 
     try {
       const result = await runMarshalTask({
@@ -148,14 +188,15 @@ export class OperatorServer {
         attachments: task.attachments,
         workspaceRoot: paths.workspaceDir,
         memoryDir: paths.memoryDir,
+        chatProjectName: session.projectId === "legacy-chats" ? undefined : session.projectName,
         onEvent: async (event) => {
-          await this.store.appendTaskEvent(sessionId, taskId, event.type, formatRuntimeEvent(event));
+          await this.store.appendTaskEvent(sessionId, taskId, event.type, formatRuntimeEvent(event), session.projectId);
         }
       });
-      await this.store.markTaskCompleted(sessionId, taskId, result);
+      await this.store.markTaskCompleted(sessionId, taskId, result, session.projectId);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown task failure.";
-      await this.store.markTaskFailed(sessionId, taskId, message);
+      await this.store.markTaskFailed(sessionId, taskId, message, session.projectId);
     }
   }
 
@@ -173,6 +214,30 @@ export class OperatorServer {
       "cache-control": "no-store"
     });
     response.end(content);
+  }
+
+  private async resumePendingTasks(): Promise<void> {
+    const sessions = await this.store.listSessions();
+
+    for (const sessionSummary of sessions) {
+      const session = await this.store.readSession(sessionSummary.id).catch(() => null);
+      if (!session) {
+        continue;
+      }
+
+      for (const task of session.tasks) {
+        if (task.status === "queued") {
+          this.enqueueTask(session.id, task.id);
+          continue;
+        }
+
+        if (task.status === "running") {
+          await this.store
+            .markTaskFailed(session.id, task.id, "Operator server restarted before task completion.", session.projectId)
+            .catch(() => undefined);
+        }
+      }
+    }
   }
 }
 

--- a/operator/session-store.ts
+++ b/operator/session-store.ts
@@ -2,61 +2,122 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import { getDefaultSessionMemory, getDefaultSessionWorkspace } from "../agent/runtime/marshal.ts";
 import type { ExecutionRoute } from "../agent/runtime/types.ts";
 import type {
   OperatorAttachment,
   OperatorMessage,
+  OperatorProjectSummary,
   OperatorSession,
   OperatorSessionSummary,
   OperatorTask,
   UploadPayload
 } from "./types.ts";
 
+const DEFAULT_PROJECT_NAME = (process.env.OPERATOR_DEFAULT_PROJECT_NAME ?? "Andrii").trim() || "Andrii";
+const LEGACY_PROJECT_ID = "legacy-chats";
+const LEGACY_PROJECT_NAME = "Imported chats";
+const SESSION_FILE_NAME = "session.json";
+const PROJECT_FILE_NAME = "project.json";
+
+type ProjectRecord = {
+  id: string;
+  name: string;
+  createdAt: string;
+  dir: string;
+  sessionsDir: string;
+  isLegacy: boolean;
+};
+
+type SessionPaths = {
+  dir: string;
+  filePath: string;
+  workspaceDir: string;
+  memoryDir: string;
+  uploadsDir: string;
+};
+
 export class OperatorSessionStore {
-  baseDir: string;
+  rootDir: string;
+  projectsDir: string;
+  legacySessionsDir: string;
   private sessionLocks = new Map<string, Promise<unknown>>();
 
-  constructor(baseDir = path.resolve(process.cwd(), "operator-data", "sessions")) {
-    this.baseDir = baseDir;
+  constructor(rootDir = path.resolve(process.cwd(), "operator-data")) {
+    this.rootDir = rootDir;
+    this.projectsDir = path.join(rootDir, "projects");
+    this.legacySessionsDir = path.join(rootDir, "sessions");
   }
 
   async initialize(): Promise<void> {
-    await fs.mkdir(this.baseDir, { recursive: true });
+    await fs.mkdir(this.rootDir, { recursive: true });
+    await fs.mkdir(this.projectsDir, { recursive: true });
+    await this.ensureProject({ name: DEFAULT_PROJECT_NAME });
   }
 
-  async listSessions(): Promise<OperatorSessionSummary[]> {
+  async listProjects(): Promise<OperatorProjectSummary[]> {
     await this.initialize();
-    const dirents = await fs.readdir(this.baseDir, { withFileTypes: true });
-    const sessions = await Promise.all(
-      dirents
-        .filter((entry) => entry.isDirectory())
-        .map(async (entry) => this.readSession(entry.name).catch(() => null))
+    const projects = await this.readProjectRecords();
+    const summaries = await Promise.all(
+      projects.map(async (project) => ({
+        id: project.id,
+        name: project.name,
+        createdAt: project.createdAt,
+        sessionCount: await this.countProjectSessions(project),
+        isDefault: project.name === DEFAULT_PROJECT_NAME,
+        isLegacy: project.isLegacy
+      }))
     );
 
+    return summaries.sort((left, right) => {
+      if (left.isDefault !== right.isDefault) {
+        return left.isDefault ? -1 : 1;
+      }
+
+      if (left.isLegacy !== right.isLegacy) {
+        return left.isLegacy ? 1 : -1;
+      }
+
+      if (right.sessionCount !== left.sessionCount) {
+        return right.sessionCount - left.sessionCount;
+      }
+
+      return left.name.localeCompare(right.name);
+    });
+  }
+
+  async createProject(name?: string): Promise<OperatorProjectSummary> {
+    const project = await this.ensureProject({ name });
+    return {
+      id: project.id,
+      name: project.name,
+      createdAt: project.createdAt,
+      sessionCount: await this.countProjectSessions(project),
+      isDefault: project.name === DEFAULT_PROJECT_NAME,
+      isLegacy: project.isLegacy
+    };
+  }
+
+  async listSessions(projectId?: string): Promise<OperatorSessionSummary[]> {
+    await this.initialize();
+    const projects = projectId
+      ? [await this.resolveProject(projectId)]
+      : await this.readProjectRecords();
+    const sessions = await Promise.all(projects.map(async (project) => this.listSessionsForProject(project)));
+
     return sessions
-      .filter((session): session is OperatorSession => session !== null)
-      .map((session) => {
-        const activeTask = session.tasks.find((task) => task.id === session.activeTaskId) ?? null;
-        return {
-          id: session.id,
-          title: session.title,
-          createdAt: session.createdAt,
-          updatedAt: session.updatedAt,
-          activeTaskId: session.activeTaskId,
-          activeTaskStatus: activeTask?.status ?? null,
-          messageCount: session.messages.length
-        };
-      })
+      .flat()
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
   }
 
-  async createSession(title?: string): Promise<OperatorSession> {
+  async createSession(title?: string, projectId?: string): Promise<OperatorSession> {
     await this.initialize();
+    const project = await this.resolveProject(projectId);
     const id = randomUUID();
     const now = new Date().toISOString();
     const session: OperatorSession = {
       id,
+      projectId: project.id,
+      projectName: project.name,
       title: title?.trim() || "New operator session",
       createdAt: now,
       updatedAt: now,
@@ -75,7 +136,7 @@ export class OperatorSessionStore {
       tasks: []
     };
 
-    const paths = this.getSessionPaths(id);
+    const paths = this.getPathsForProject(project, id);
     await fs.mkdir(paths.dir, { recursive: true });
     await fs.mkdir(paths.workspaceDir, { recursive: true });
     await fs.mkdir(paths.memoryDir, { recursive: true });
@@ -83,13 +144,26 @@ export class OperatorSessionStore {
     return session;
   }
 
-  async readSession(sessionId: string): Promise<OperatorSession> {
-    const raw = await fs.readFile(this.getSessionPaths(sessionId).filePath, "utf8");
-    return JSON.parse(raw) as OperatorSession;
+  async readSession(sessionId: string, projectId?: string): Promise<OperatorSession> {
+    const located = await this.locateSession(sessionId, projectId);
+    const raw = await fs.readFile(located.paths.filePath, "utf8");
+    return normalizeSession(JSON.parse(raw) as Partial<OperatorSession>, located.project);
+  }
+
+  async deleteSession(sessionId: string, projectId?: string): Promise<void> {
+    const session = await this.readSession(sessionId, projectId);
+    const activeTask = session.tasks.find((task) => task.status === "queued" || task.status === "running");
+    if (activeTask) {
+      throw new Error("Cannot delete a chat while a task is queued or running.");
+    }
+
+    const paths = await this.getSessionPaths(sessionId, projectId);
+    await fs.rm(paths.dir, { recursive: true, force: true });
   }
 
   async createTaskFromMessage(input: {
     sessionId: string;
+    projectId?: string;
     text: string;
     route: ExecutionRoute;
     uploads: UploadPayload[];
@@ -100,8 +174,8 @@ export class OperatorSessionStore {
     }
 
     return this.withSessionLock(input.sessionId, async () => {
-      const session = await this.readSession(input.sessionId);
-      const attachments = await this.saveUploads(input.sessionId, input.uploads);
+      const session = await this.readSession(input.sessionId, input.projectId);
+      const attachments = await this.saveUploads(input.sessionId, session.projectId, input.uploads);
       const now = new Date().toISOString();
       const taskId = randomUUID();
       const task: OperatorTask = {
@@ -146,8 +220,8 @@ export class OperatorSessionStore {
     });
   }
 
-  async markTaskRunning(sessionId: string, taskId: string): Promise<void> {
-    await this.mutateSession(sessionId, (session) => {
+  async markTaskRunning(sessionId: string, taskId: string, projectId?: string): Promise<void> {
+    await this.mutateSession(sessionId, projectId, (session) => {
       const task = findTask(session, taskId);
       const now = new Date().toISOString();
       task.status = "running";
@@ -163,8 +237,8 @@ export class OperatorSessionStore {
     });
   }
 
-  async appendTaskEvent(sessionId: string, taskId: string, type: string, detail: string): Promise<void> {
-    await this.mutateSession(sessionId, (session) => {
+  async appendTaskEvent(sessionId: string, taskId: string, type: string, detail: string, projectId?: string): Promise<void> {
+    await this.mutateSession(sessionId, projectId, (session) => {
       const task = findTask(session, taskId);
       const now = new Date().toISOString();
       task.events.push({
@@ -177,8 +251,8 @@ export class OperatorSessionStore {
     });
   }
 
-  async markTaskCompleted(sessionId: string, taskId: string, result: string): Promise<void> {
-    await this.mutateSession(sessionId, (session) => {
+  async markTaskCompleted(sessionId: string, taskId: string, result: string, projectId?: string): Promise<void> {
+    await this.mutateSession(sessionId, projectId, (session) => {
       const task = findTask(session, taskId);
       const now = new Date().toISOString();
       task.status = "completed";
@@ -204,8 +278,8 @@ export class OperatorSessionStore {
     });
   }
 
-  async markTaskFailed(sessionId: string, taskId: string, error: string): Promise<void> {
-    await this.mutateSession(sessionId, (session) => {
+  async markTaskFailed(sessionId: string, taskId: string, error: string, projectId?: string): Promise<void> {
+    await this.mutateSession(sessionId, projectId, (session) => {
       const task = findTask(session, taskId);
       const now = new Date().toISOString();
       task.status = "failed";
@@ -231,29 +305,201 @@ export class OperatorSessionStore {
     });
   }
 
-  getSessionPaths(sessionId: string): {
-    dir: string;
-    filePath: string;
-    workspaceDir: string;
-    memoryDir: string;
-    uploadsDir: string;
-  } {
-    const dir = path.join(this.baseDir, sessionId);
+  async getSessionPaths(sessionId: string, projectId?: string): Promise<SessionPaths> {
+    const located = await this.locateSession(sessionId, projectId);
+    return located.paths;
+  }
+
+  private async listSessionsForProject(project: ProjectRecord): Promise<OperatorSessionSummary[]> {
+    await fs.mkdir(project.sessionsDir, { recursive: true });
+    const dirents = await fs.readdir(project.sessionsDir, { withFileTypes: true });
+    const sessions = await Promise.all(
+      dirents
+        .filter((entry) => entry.isDirectory())
+        .map(async (entry) => this.readSession(entry.name, project.id).catch(() => null))
+    );
+
+    return sessions
+      .filter((session): session is OperatorSession => session !== null)
+      .map((session) => {
+        const activeTask = session.tasks.find((task) => task.id === session.activeTaskId) ?? null;
+        return {
+          id: session.id,
+          projectId: session.projectId,
+          projectName: session.projectName,
+          title: session.title,
+          createdAt: session.createdAt,
+          updatedAt: session.updatedAt,
+          activeTaskId: session.activeTaskId,
+          activeTaskStatus: activeTask?.status ?? null,
+          messageCount: session.messages.length
+        };
+      });
+  }
+
+  private async readProjectRecords(): Promise<ProjectRecord[]> {
+    const projects: ProjectRecord[] = [];
+    const dirents = await fs.readdir(this.projectsDir, { withFileTypes: true }).catch(() => []);
+
+    for (const entry of dirents) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const dir = path.join(this.projectsDir, entry.name);
+      const projectFilePath = path.join(dir, PROJECT_FILE_NAME);
+      const raw = await fs.readFile(projectFilePath, "utf8").catch(() => null);
+      if (!raw) {
+        continue;
+      }
+
+      const parsed = JSON.parse(raw) as Partial<Pick<ProjectRecord, "id" | "name" | "createdAt">>;
+      const id = typeof parsed.id === "string" && parsed.id.trim() ? parsed.id : entry.name;
+      const name = typeof parsed.name === "string" && parsed.name.trim() ? parsed.name : entry.name;
+      const createdAt =
+        typeof parsed.createdAt === "string" && parsed.createdAt.trim()
+          ? parsed.createdAt
+          : new Date().toISOString();
+
+      projects.push({
+        id,
+        name,
+        createdAt,
+        dir,
+        sessionsDir: path.join(dir, "sessions"),
+        isLegacy: false
+      });
+    }
+
+    const legacyExists = await hasDirectory(this.legacySessionsDir);
+    if (legacyExists) {
+      const legacyCount = await countDirectories(this.legacySessionsDir);
+      if (legacyCount > 0) {
+        projects.push({
+          id: LEGACY_PROJECT_ID,
+          name: LEGACY_PROJECT_NAME,
+          createdAt: new Date(0).toISOString(),
+          dir: this.legacySessionsDir,
+          sessionsDir: this.legacySessionsDir,
+          isLegacy: true
+        });
+      }
+    }
+
+    return projects;
+  }
+
+  private async ensureProject(input: { id?: string; name?: string }): Promise<ProjectRecord> {
+    await fs.mkdir(this.projectsDir, { recursive: true });
+    const requestedId = input.id?.trim();
+    const requestedName = input.name?.trim() || DEFAULT_PROJECT_NAME;
+    const existing = await this.readProjectRecords();
+
+    if (requestedId) {
+      const matchedById = existing.find((project) => project.id === requestedId);
+      if (matchedById) {
+        return matchedById;
+      }
+    }
+
+    const matchedByName = existing.find(
+      (project) => !project.isLegacy && project.name.toLowerCase() === requestedName.toLowerCase()
+    );
+    if (matchedByName) {
+      return matchedByName;
+    }
+
+    const existingIds = new Set(existing.map((project) => project.id));
+    const baseId = slugifyProjectId(requestedId || requestedName);
+    let projectId = baseId;
+    let suffix = 2;
+    while (existingIds.has(projectId)) {
+      projectId = `${baseId}-${suffix}`;
+      suffix += 1;
+    }
+
+    const createdAt = new Date().toISOString();
+    const dir = path.join(this.projectsDir, projectId);
+    const project: ProjectRecord = {
+      id: projectId,
+      name: requestedName,
+      createdAt,
+      dir,
+      sessionsDir: path.join(dir, "sessions"),
+      isLegacy: false
+    };
+
+    await fs.mkdir(project.sessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(project.dir, PROJECT_FILE_NAME),
+      JSON.stringify(
+        {
+          id: project.id,
+          name: project.name,
+          createdAt: project.createdAt
+        },
+        null,
+        2
+      ) + "\n",
+      "utf8"
+    );
+
+    return project;
+  }
+
+  private async resolveProject(projectId?: string): Promise<ProjectRecord> {
+    if (!projectId) {
+      return this.ensureProject({ name: DEFAULT_PROJECT_NAME });
+    }
+
+    const projects = await this.readProjectRecords();
+    const matched = projects.find((project) => project.id === projectId);
+    if (matched) {
+      return matched;
+    }
+
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  private async locateSession(
+    sessionId: string,
+    projectId?: string
+  ): Promise<{ project: ProjectRecord; paths: SessionPaths }> {
+    const projects = projectId
+      ? [await this.resolveProject(projectId)]
+      : await this.readProjectRecords();
+
+    for (const project of projects) {
+      const paths = this.getPathsForProject(project, sessionId);
+      if (await hasFile(paths.filePath)) {
+        return { project, paths };
+      }
+    }
+
+    throw new Error(`Session not found: ${sessionId}`);
+  }
+
+  private getPathsForProject(project: ProjectRecord, sessionId: string): SessionPaths {
+    const dir = path.join(project.sessionsDir, sessionId);
     return {
       dir,
-      filePath: path.join(dir, "session.json"),
-      workspaceDir: getDefaultSessionWorkspace(sessionId),
-      memoryDir: getDefaultSessionMemory(sessionId),
-      uploadsDir: path.join(getDefaultSessionWorkspace(sessionId), "uploads")
+      filePath: path.join(dir, SESSION_FILE_NAME),
+      workspaceDir: path.join(dir, "workspace"),
+      memoryDir: path.join(dir, "memory"),
+      uploadsDir: path.join(dir, "workspace", "uploads")
     };
   }
 
-  private async saveUploads(sessionId: string, uploads: UploadPayload[]): Promise<OperatorAttachment[]> {
+  private async saveUploads(
+    sessionId: string,
+    projectId: string,
+    uploads: UploadPayload[]
+  ): Promise<OperatorAttachment[]> {
     if (uploads.length === 0) {
       return [];
     }
 
-    const paths = this.getSessionPaths(sessionId);
+    const paths = await this.getSessionPaths(sessionId, projectId);
     await fs.mkdir(paths.uploadsDir, { recursive: true });
 
     return Promise.all(
@@ -277,20 +523,29 @@ export class OperatorSessionStore {
     );
   }
 
-  private async mutateSession(sessionId: string, mutate: (session: OperatorSession) => void): Promise<void> {
+  private async mutateSession(
+    sessionId: string,
+    projectId: string | undefined,
+    mutate: (session: OperatorSession) => void
+  ): Promise<void> {
     await this.withSessionLock(sessionId, async () => {
-      const session = await this.readSession(sessionId);
+      const session = await this.readSession(sessionId, projectId);
       mutate(session);
       await this.writeSession(session);
     });
   }
 
   private async writeSession(session: OperatorSession): Promise<void> {
-    const paths = this.getSessionPaths(session.id);
+    const project = await this.resolveProject(session.projectId);
+    const paths = this.getPathsForProject(project, session.id);
     await fs.mkdir(paths.dir, { recursive: true });
     const tmpPath = `${paths.filePath}.tmp`;
     await fs.writeFile(tmpPath, JSON.stringify(session, null, 2) + "\n", "utf8");
     await fs.rename(tmpPath, paths.filePath);
+  }
+
+  private async countProjectSessions(project: ProjectRecord): Promise<number> {
+    return countDirectories(project.sessionsDir);
   }
 
   private async withSessionLock<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
@@ -321,6 +576,47 @@ function findTask(session: OperatorSession, taskId: string): OperatorTask {
   return task;
 }
 
-function sanitizeFilename(fileName: string): string {
-  return fileName.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "") || "upload.bin";
+function sanitizeFilename(input: string): string {
+  return input.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "upload.bin";
+}
+
+function slugifyProjectId(input: string): string {
+  const slug = input
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || "project";
+}
+
+function normalizeSession(raw: Partial<OperatorSession>, project: ProjectRecord): OperatorSession {
+  return {
+    id: String(raw.id ?? ""),
+    projectId: typeof raw.projectId === "string" && raw.projectId.trim() ? raw.projectId : project.id,
+    projectName: typeof raw.projectName === "string" && raw.projectName.trim() ? raw.projectName : project.name,
+    title: typeof raw.title === "string" && raw.title.trim() ? raw.title : "Untitled session",
+    createdAt: typeof raw.createdAt === "string" ? raw.createdAt : new Date().toISOString(),
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date().toISOString(),
+    activeTaskId: typeof raw.activeTaskId === "string" ? raw.activeTaskId : null,
+    messages: Array.isArray(raw.messages) ? (raw.messages as OperatorMessage[]) : [],
+    tasks: Array.isArray(raw.tasks) ? (raw.tasks as OperatorTask[]) : []
+  };
+}
+
+async function hasDirectory(targetPath: string): Promise<boolean> {
+  const stat = await fs.stat(targetPath).catch(() => null);
+  return Boolean(stat?.isDirectory());
+}
+
+async function hasFile(targetPath: string): Promise<boolean> {
+  const stat = await fs.stat(targetPath).catch(() => null);
+  return Boolean(stat?.isFile());
+}
+
+async function countDirectories(targetPath: string): Promise<number> {
+  const dirents = await fs.readdir(targetPath, { withFileTypes: true }).catch(() => []);
+  return dirents.filter((entry) => entry.isDirectory()).length;
 }

--- a/operator/static/app.js
+++ b/operator/static/app.js
@@ -1,12 +1,18 @@
+const PROJECT_STORAGE_KEY = "marshal-active-project";
+
 const state = {
+  projects: [],
   sessions: [],
   activeSessionId: null,
+  selectedProjectId: null,
   pendingFiles: [],
-  pollHandle: null
+  pollHandle: null,
+  logExpanded: false
 };
 
 const sessionList = document.querySelector("#session-list");
 const sessionTitle = document.querySelector("#session-title");
+const projectChip = document.querySelector("#project-chip");
 const messagesEl = document.querySelector("#messages");
 const taskEventsEl = document.querySelector("#task-events");
 const attachmentList = document.querySelector("#attachment-list");
@@ -15,6 +21,9 @@ const routeSelect = document.querySelector("#route-select");
 const taskInput = document.querySelector("#task-input");
 const composer = document.querySelector("#composer");
 const newSessionButton = document.querySelector("#new-session-button");
+const newProjectButton = document.querySelector("#new-project-button");
+const projectSelect = document.querySelector("#project-select");
+const toggleEventsButton = document.querySelector("#toggle-events-button");
 
 fileInput.addEventListener("change", async () => {
   state.pendingFiles = Array.from(fileInput.files ?? []);
@@ -22,21 +31,51 @@ fileInput.addEventListener("change", async () => {
 });
 
 newSessionButton.addEventListener("click", async () => {
+  if (!state.selectedProjectId) {
+    return;
+  }
+
   const session = await createSession();
+  await refreshProjects();
   await refreshSessions();
   state.activeSessionId = session.id;
   await loadSession(session.id);
 });
 
+newProjectButton.addEventListener("click", async () => {
+  const name = window.prompt("Project name");
+  if (!name || !name.trim()) {
+    return;
+  }
+
+  const project = await createProject(name.trim());
+  await refreshProjects(project.id);
+  await handleProjectChange(project.id);
+});
+
+projectSelect.addEventListener("change", async () => {
+  const projectId = projectSelect.value || null;
+  if (!projectId || projectId === state.selectedProjectId) {
+    return;
+  }
+
+  await handleProjectChange(projectId);
+});
+
+toggleEventsButton.addEventListener("click", () => {
+  state.logExpanded = !state.logExpanded;
+  renderEventsVisibility();
+});
+
 composer.addEventListener("submit", async (event) => {
   event.preventDefault();
   const text = taskInput.value.trim();
-  if (!text || !state.activeSessionId) {
+  if (!text || !state.activeSessionId || !state.selectedProjectId) {
     return;
   }
 
   const attachments = await Promise.all(state.pendingFiles.map(fileToUploadPayload));
-  await fetch(`/api/sessions/${state.activeSessionId}/messages`, {
+  await requestJson(`${sessionPath(state.activeSessionId)}/messages?${projectQuery()}`, {
     method: "POST",
     headers: {
       "content-type": "application/json"
@@ -52,39 +91,82 @@ composer.addEventListener("submit", async (event) => {
   state.pendingFiles = [];
   fileInput.value = "";
   renderPendingFiles();
+  await refreshProjects();
   await refreshSessions();
   await loadSession(state.activeSessionId);
 });
 
 async function bootstrap() {
-  await refreshSessions();
-  if (state.sessions.length === 0) {
-    const session = await createSession();
-    await refreshSessions();
-    state.activeSessionId = session.id;
-  } else {
-    state.activeSessionId = state.sessions[0].id;
-  }
+  await refreshProjects();
+  await handleProjectChange(getInitialProjectId());
 
-  await loadSession(state.activeSessionId);
   state.pollHandle = window.setInterval(async () => {
     await refreshSessions();
+    if (!state.activeSessionId) {
+      renderComposerState();
+      return;
+    }
+
+    if (!state.sessions.some((session) => session.id === state.activeSessionId)) {
+      state.activeSessionId = state.sessions[0]?.id ?? null;
+    }
+
     if (state.activeSessionId) {
       await loadSession(state.activeSessionId, false);
+    } else {
+      renderEmptySession();
     }
   }, 2000);
 }
 
+async function handleProjectChange(projectId) {
+  state.selectedProjectId = projectId;
+  localStorage.setItem(PROJECT_STORAGE_KEY, projectId);
+  projectSelect.value = projectId;
+  await refreshSessions();
+
+  if (!state.sessions.some((session) => session.id === state.activeSessionId)) {
+    state.activeSessionId = state.sessions[0]?.id ?? null;
+  }
+
+  if (state.activeSessionId) {
+    await loadSession(state.activeSessionId);
+  } else {
+    renderSessions();
+    renderEmptySession();
+  }
+}
+
+async function refreshProjects(preferredProjectId = state.selectedProjectId) {
+  const payload = await requestJson("/api/projects");
+  state.projects = payload.data ?? [];
+  const nextProjectId =
+    preferredProjectId && state.projects.some((project) => project.id === preferredProjectId)
+      ? preferredProjectId
+      : getInitialProjectId();
+  state.selectedProjectId = nextProjectId;
+  renderProjects();
+}
+
 async function refreshSessions() {
-  const response = await fetch("/api/sessions");
-  const payload = await response.json();
+  if (!state.selectedProjectId) {
+    state.sessions = [];
+    renderSessions();
+    return;
+  }
+
+  const payload = await requestJson(`/api/sessions?${projectQuery()}`);
   state.sessions = payload.data ?? [];
   renderSessions();
 }
 
 async function loadSession(sessionId, scroll = true) {
-  const response = await fetch(`/api/sessions/${sessionId}`);
-  const payload = await response.json();
+  if (!state.selectedProjectId) {
+    renderEmptySession();
+    return;
+  }
+
+  const payload = await requestJson(`${sessionPath(sessionId)}?${projectQuery()}`);
   const session = payload.data;
   if (!session) {
     return;
@@ -92,42 +174,117 @@ async function loadSession(sessionId, scroll = true) {
 
   state.activeSessionId = session.id;
   sessionTitle.textContent = session.title;
+  projectChip.textContent = session.projectName;
   renderSessions();
   renderMessages(session);
   renderEvents(session);
+  renderEventsVisibility();
+  renderComposerState();
   if (scroll) {
     messagesEl.scrollTop = messagesEl.scrollHeight;
   }
 }
 
-async function createSession() {
-  const response = await fetch("/api/sessions", {
+async function createProject(name) {
+  const payload = await requestJson("/api/projects", {
     method: "POST",
     headers: {
       "content-type": "application/json"
     },
-    body: JSON.stringify({})
+    body: JSON.stringify({ name })
   });
-  const payload = await response.json();
   return payload.data;
+}
+
+async function createSession() {
+  const payload = await requestJson("/api/sessions", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      projectId: state.selectedProjectId
+    })
+  });
+  return payload.data;
+}
+
+async function deleteSession(sessionId) {
+  if (!window.confirm("Delete this chat?")) {
+    return;
+  }
+
+  await requestJson(`${sessionPath(sessionId)}?${projectQuery()}`, {
+    method: "DELETE"
+  });
+
+  if (state.activeSessionId === sessionId) {
+    state.activeSessionId = null;
+  }
+
+  await refreshProjects();
+  await refreshSessions();
+  state.activeSessionId = state.sessions[0]?.id ?? null;
+
+  if (state.activeSessionId) {
+    await loadSession(state.activeSessionId);
+    return;
+  }
+
+  renderEmptySession();
+}
+
+function renderProjects() {
+  projectSelect.innerHTML = "";
+
+  state.projects.forEach((project) => {
+    const option = document.createElement("option");
+    option.value = project.id;
+    option.textContent = `${project.name} (${project.sessionCount})`;
+    projectSelect.appendChild(option);
+  });
+
+  if (state.selectedProjectId) {
+    projectSelect.value = state.selectedProjectId;
+  }
 }
 
 function renderSessions() {
   sessionList.innerHTML = "";
+
+  if (state.sessions.length === 0) {
+    sessionList.innerHTML = `<p class="empty-state">No chats in this project yet.</p>`;
+    return;
+  }
+
   state.sessions.forEach((session) => {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = `session-card${session.id === state.activeSessionId ? " active" : ""}`;
-    button.innerHTML = `
+    const article = document.createElement("article");
+    article.className = `session-card${session.id === state.activeSessionId ? " active" : ""}`;
+
+    const openButton = document.createElement("button");
+    openButton.type = "button";
+    openButton.className = "session-open-button";
+    openButton.innerHTML = `
       <span class="session-title">${escapeHtml(session.title)}</span>
       <span class="session-meta">${escapeHtml(session.updatedAt)}</span>
       <span class="session-meta">${escapeHtml(session.activeTaskStatus ?? "idle")}</span>
     `;
-    button.addEventListener("click", async () => {
+    openButton.addEventListener("click", async () => {
       state.activeSessionId = session.id;
       await loadSession(session.id);
     });
-    sessionList.appendChild(button);
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "session-delete-button";
+    deleteButton.textContent = "Delete";
+    deleteButton.addEventListener("click", async (event) => {
+      event.stopPropagation();
+      await deleteSession(session.id);
+    });
+
+    article.append(openButton, deleteButton);
+    sessionList.appendChild(article);
   });
 }
 
@@ -157,6 +314,12 @@ function renderMessages(session) {
 function renderEvents(session) {
   taskEventsEl.innerHTML = "";
   const tasks = [...session.tasks].reverse();
+
+  if (tasks.length === 0) {
+    taskEventsEl.innerHTML = `<p class="empty-state">Execution log will appear after the first task.</p>`;
+    return;
+  }
+
   tasks.forEach((task) => {
     const section = document.createElement("section");
     section.className = "task-card";
@@ -186,10 +349,67 @@ function renderEvents(session) {
   });
 }
 
+function renderEventsVisibility() {
+  taskEventsEl.classList.toggle("hidden", !state.logExpanded || !state.activeSessionId);
+  toggleEventsButton.textContent = state.logExpanded ? "Hide Execution Log" : "Show Execution Log";
+}
+
 function renderPendingFiles() {
   attachmentList.innerHTML = state.pendingFiles
     .map((file) => `<span class="pending-file">${escapeHtml(file.name)} (${file.size} bytes)</span>`)
     .join("");
+}
+
+function renderEmptySession() {
+  sessionTitle.textContent = "No chat selected";
+  projectChip.textContent = getSelectedProject()?.name ?? "Project";
+  messagesEl.innerHTML = `<p class="empty-state">Choose a chat on the left or create a new one.</p>`;
+  taskEventsEl.innerHTML = "";
+  renderEventsVisibility();
+  renderComposerState();
+}
+
+function renderComposerState() {
+  const disabled = !state.activeSessionId;
+  taskInput.disabled = disabled;
+  routeSelect.disabled = disabled;
+  fileInput.disabled = disabled;
+  composer.querySelector("#send-button").disabled = disabled;
+  taskInput.placeholder = disabled ? "Create or select a chat first." : "Describe what Marshal should do.";
+}
+
+function getInitialProjectId() {
+  const savedProjectId = localStorage.getItem(PROJECT_STORAGE_KEY);
+  if (savedProjectId && state.projects.some((project) => project.id === savedProjectId)) {
+    return savedProjectId;
+  }
+
+  return state.projects.find((project) => project.isDefault)?.id ?? state.projects[0]?.id ?? null;
+}
+
+function getSelectedProject() {
+  return state.projects.find((project) => project.id === state.selectedProjectId) ?? null;
+}
+
+function projectQuery() {
+  const params = new URLSearchParams();
+  if (state.selectedProjectId) {
+    params.set("projectId", state.selectedProjectId);
+  }
+  return params.toString();
+}
+
+function sessionPath(sessionId) {
+  return `/api/sessions/${encodeURIComponent(sessionId)}`;
+}
+
+async function requestJson(url, options) {
+  const response = await fetch(url, options);
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload.ok === false) {
+    throw new Error(payload.error || `Request failed: ${response.status}`);
+  }
+  return payload;
 }
 
 async function fileToUploadPayload(file) {

--- a/operator/static/index.html
+++ b/operator/static/index.html
@@ -16,6 +16,13 @@
           </div>
           <button id="new-session-button" class="secondary-button">New Session</button>
         </div>
+        <div class="sidebar-controls">
+          <label class="field compact-field">
+            <span>ChatGPT Project</span>
+            <select id="project-select"></select>
+          </label>
+          <button id="new-project-button" class="secondary-button">New Project</button>
+        </div>
         <div id="session-list" class="session-list"></div>
       </aside>
       <main class="main-panel">
@@ -25,13 +32,15 @@
             <h2 id="session-title">Loading...</h2>
           </div>
           <div class="status-strip">
+            <span id="project-chip" class="status-chip">Project</span>
             <span class="status-chip">Persistent history</span>
-            <span class="status-chip">Local routing</span>
-            <span class="status-chip">Browser routing</span>
+            <button id="toggle-events-button" type="button" class="secondary-button inline-button">
+              Show Execution Log
+            </button>
           </div>
         </header>
         <section id="messages" class="messages"></section>
-        <section id="task-events" class="task-events"></section>
+        <section id="task-events" class="task-events hidden"></section>
         <form id="composer" class="composer">
           <label class="field">
             <span>Task</span>

--- a/operator/static/index.html
+++ b/operator/static/index.html
@@ -54,6 +54,7 @@
                 <option value="local">Local only</option>
                 <option value="browser">Browser only</option>
               </select>
+              <small>Local tools work only inside the session workspace, not arbitrary system paths.</small>
             </label>
             <label class="field compact-field">
               <span>Attachments</span>

--- a/operator/static/styles.css
+++ b/operator/static/styles.css
@@ -244,6 +244,11 @@ input[type="file"] {
   font-size: 14px;
 }
 
+.field small {
+  color: var(--muted);
+  line-height: 1.4;
+}
+
 .compact-field {
   min-width: 220px;
 }

--- a/operator/static/styles.css
+++ b/operator/static/styles.css
@@ -79,7 +79,15 @@ p {
   margin-top: 20px;
 }
 
+.sidebar-controls {
+  margin-top: 20px;
+  display: grid;
+  gap: 12px;
+}
+
 .session-card,
+.session-open-button,
+.session-delete-button,
 .primary-button,
 .secondary-button,
 select,
@@ -94,17 +102,42 @@ input[type="file"] {
   border: 1px solid var(--border);
   background: var(--panel);
   box-shadow: var(--shadow);
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
   color: inherit;
-  cursor: pointer;
 }
 
 .session-card.active {
   border-color: var(--accent);
   background: linear-gradient(135deg, rgba(11, 92, 86, 0.12), rgba(255, 253, 248, 0.96));
+}
+
+.session-open-button,
+.session-delete-button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.session-open-button {
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  text-align: left;
+  padding: 0;
+}
+
+.session-delete-button {
+  align-self: start;
+  padding: 8px 12px;
+  border: 1px solid rgba(143, 49, 32, 0.25);
+  background: rgba(143, 49, 32, 0.08);
+  color: var(--danger);
+  cursor: pointer;
 }
 
 .session-title {
@@ -233,10 +266,10 @@ textarea {
 
 .primary-button,
 .secondary-button {
-  border: 0;
   padding: 12px 18px;
   font: inherit;
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .primary-button {
@@ -248,6 +281,30 @@ textarea {
   background: var(--panel-strong);
   color: var(--text);
   border: 1px solid var(--border);
+}
+
+.inline-button {
+  padding: 8px 14px;
+}
+
+.hidden {
+  display: none;
+}
+
+.empty-state {
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px dashed var(--border);
+  background: rgba(255, 253, 248, 0.8);
+  color: var(--muted);
+}
+
+button:disabled,
+textarea:disabled,
+select:disabled,
+input[type="file"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 @media (max-width: 960px) {

--- a/operator/types.ts
+++ b/operator/types.ts
@@ -43,6 +43,8 @@ export type OperatorMessage = {
 
 export type OperatorSession = {
   id: string;
+  projectId: string;
+  projectName: string;
   title: string;
   createdAt: string;
   updatedAt: string;
@@ -53,10 +55,21 @@ export type OperatorSession = {
 
 export type OperatorSessionSummary = {
   id: string;
+  projectId: string;
+  projectName: string;
   title: string;
   createdAt: string;
   updatedAt: string;
   activeTaskId: string | null;
   activeTaskStatus: OperatorTaskStatus | null;
   messageCount: number;
+};
+
+export type OperatorProjectSummary = {
+  id: string;
+  name: string;
+  createdAt: string;
+  sessionCount: number;
+  isDefault: boolean;
+  isLegacy: boolean;
 };


### PR DESCRIPTION
## Summary

This PR does two things that were discovered during live use of Marshal.

First, it hardens task proofing in the agent loop. The operator flow could previously report file-system success based only on the model's step summary, even when no successful tool result had actually proven the step. In practice that let tasks claim that files were written and verified outside the workspace when the sandbox should have blocked them. This PR tightens the planner prompt and blocks `FINAL` for tool-shaped steps until at least one successful tool result exists for that step.

Second, it documents and stages the macOS menu bar direction as the next product surface for Marshal. The repository now includes a dedicated architecture plan that evaluates Electron, Tauri, and native Swift/AppKit approaches and recommends an Electron menu bar shell on top of the current runtime, operator store, and ChatGPT bridge.

## User impact

Users should no longer see Marshal claim file creation success without actual tool confirmation for steps that clearly require tools. This reduces false-positive task completions and makes filesystem results more trustworthy.

Users also now have an in-repo implementation roadmap for the macOS menu bar app, with explicit phases, architecture seams, risks, and acceptance criteria. That plan is also reflected in the main project plan and status tracker.

## Root cause

The current loop trusted `FINAL:` step summaries too early. Even though the step prompt told the model not to claim unverified side effects, the runtime did not enforce that rule. Separately, the project lacked a committed architecture document for the menu bar direction, so the work was not captured in the repo's tracked roadmap.

## Fix

The loop now detects steps that are clearly tool-oriented, such as steps naming a tool or containing explicit paths/URLs, and refuses to accept `FINAL` until a successful tool result has occurred for that step. The planner prompt now also asks for explicit tool-named steps instead of purely mental ones for filesystem, shell, or browser work.

The Chrome profile launcher was also updated so Marshal reuses its own managed `Andrii` Chrome session instead of asking to close all of Chrome, which would incorrectly affect unrelated profiles. The ChatGPT extension setup docs were updated to match that behavior.

Finally, a new `docs/MENUBAR_APP_PLAN.md` document was added and the repo-wide project plan/status files were updated to include the new macOS menu bar phase.

## Validation

I ran:

- `npm run check`
- `npm run build`
- `sh -n open-chatgpt-browser-default-profile.sh`
- `CHATGPT_BROWSER_DRY_RUN=1 ./open-chatgpt-browser-default-profile.sh`
- `./open-chatgpt-browser-default-profile.sh`
- a local Node harness against the built agent loop to confirm that a tool-required step now blocks premature `FINAL` and only completes after a successful tool action
