### PR TITLE
[codex] Close phase 4 smoke validation

### DIFF
--- a/agent/bridge/scripted.ts
+++ b/agent/bridge/scripted.ts
@@ -1,0 +1,91 @@
+import type { ToolName } from "../core/protocol.ts";
+import type { ReasoningBridge } from "./types.ts";
+
+type ScriptedActionTurn = {
+  kind: "action";
+  thought: string;
+  action: ToolName;
+  input: Record<string, unknown>;
+};
+
+type ScriptedFinalTurn = {
+  kind: "final";
+  result: string;
+};
+
+export type ScriptedTurn = ScriptedActionTurn | ScriptedFinalTurn;
+
+export type ScriptedBridgeScenario = {
+  plan: string[];
+  turnsByStep: Record<string, ScriptedTurn[]>;
+  finalResult: string;
+};
+
+export class ScriptedReasoningBridge implements ReasoningBridge {
+  private readonly scenario: ScriptedBridgeScenario;
+  private readonly stepTurnCounts = new Map<string, number>();
+
+  constructor(scenario: ScriptedBridgeScenario) {
+    this.scenario = scenario;
+  }
+
+  async initialize(): Promise<void> {}
+
+  async openLoginWindow(): Promise<void> {
+    throw new Error("ScriptedReasoningBridge does not support login flows.");
+  }
+
+  async resetConversation(): Promise<void> {
+    this.stepTurnCounts.clear();
+  }
+
+  async prime(_initialPrompt: string): Promise<void> {}
+
+  async ask(prompt: string): Promise<string> {
+    if (prompt.startsWith("Create a concise execution plan for the task below.")) {
+      return JSON.stringify({ steps: this.scenario.plan });
+    }
+
+    if (prompt.startsWith("RESULT:\n") || prompt.startsWith("FORMAT ERROR.") || prompt.startsWith("STEP COMPLETION BLOCKED.")) {
+      return "ACK";
+    }
+
+    const currentStep = readCurrentStep(prompt);
+    if (currentStep) {
+      const turns = this.scenario.turnsByStep[currentStep];
+      if (!turns) {
+        throw new Error(`No scripted turns configured for step: ${currentStep}`);
+      }
+
+      const currentTurn = this.stepTurnCounts.get(currentStep) ?? 0;
+      const turn = turns[currentTurn];
+      if (!turn) {
+        throw new Error(`No scripted turn ${currentTurn + 1} configured for step: ${currentStep}`);
+      }
+
+      this.stepTurnCounts.set(currentStep, currentTurn + 1);
+      return formatTurn(turn);
+    }
+
+    if (prompt.startsWith("Task: ") && prompt.includes("Return the final answer as:")) {
+      return `FINAL: ${this.scenario.finalResult}`;
+    }
+
+    throw new Error(`Unexpected prompt for ScriptedReasoningBridge:\n${prompt}`);
+  }
+
+  async close(): Promise<void> {}
+}
+
+function readCurrentStep(prompt: string): string | null {
+  const match = prompt.match(/Current plan step \(\d+\/\d+\): ([^\n]+)/);
+  return match?.[1]?.trim() || null;
+}
+
+function formatTurn(turn: ScriptedTurn): string {
+  if (turn.kind === "final") {
+    return `FINAL: ${turn.result}`;
+  }
+
+  return [`THOUGHT: ${turn.thought}`, `ACTION: ${turn.action}`, `INPUT: ${JSON.stringify(turn.input)}`].join("\n");
+}

--- a/agent/runtime/marshal.ts
+++ b/agent/runtime/marshal.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import { createReasoningBridge } from "../bridge/factory.ts";
+import type { ReasoningBridge } from "../bridge/types.ts";
 import { AgentLoop } from "../core/agent-loop.ts";
 import { Planner } from "../core/planner.ts";
 import { ALL_TOOL_NAMES, createInitialSystemPrompt, type ToolName } from "../core/protocol.ts";
@@ -25,15 +26,17 @@ export type RunMarshalTaskOptions = {
   workspaceRoot?: string;
   memoryDir?: string;
   chatProjectName?: string;
+  bridge?: ReasoningBridge;
+  browserHeadless?: boolean;
   onEvent?: (event: MarshalRuntimeEvent) => Promise<void> | void;
 };
 
 export async function runMarshalTask(options: RunMarshalTaskOptions): Promise<string> {
   const route = options.route ?? "auto";
-  const bridge = createReasoningBridge({ projectName: options.chatProjectName });
+  const bridge = options.bridge ?? createReasoningBridge({ projectName: options.chatProjectName });
   const memory = new MemoryStore(options.memoryDir);
   const sandbox = new FileSandbox(options.workspaceRoot);
-  const browserManager = new PlaywrightBrowserManager(false);
+  const browserManager = new PlaywrightBrowserManager(options.browserHeadless ?? false);
   const allowedTools = ROUTE_TOOL_MAP[route];
   const task = buildExecutionTask(options.task, route, options.attachments ?? [], sandbox.root);
 

--- a/agent/smoke/phase4.ts
+++ b/agent/smoke/phase4.ts
@@ -1,0 +1,237 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+
+import { ScriptedReasoningBridge, type ScriptedBridgeScenario } from "../bridge/scripted.ts";
+import type { MarshalRuntimeEvent } from "../runtime/types.ts";
+import { runMarshalTask } from "../runtime/marshal.ts";
+
+async function main(): Promise<void> {
+  const workspaceRoot = path.resolve(process.cwd(), "agent/workspace/phase4-smoke");
+  const memoryDir = path.resolve(process.cwd(), "agent/memory/phase4-smoke");
+  await fs.rm(workspaceRoot, { recursive: true, force: true });
+  await fs.rm(memoryDir, { recursive: true, force: true });
+
+  const server = await startBrowserSmokeServer();
+  const browserUrl = `http://127.0.0.1:${server.port}/`;
+  const events: MarshalRuntimeEvent[] = [];
+
+  const scenario = buildScenario(browserUrl);
+  const result = await runMarshalTask({
+    task: [
+      "Run the Phase 4 smoke validation.",
+      "Exercise filesystem, shell, and browser tools through the normal agent loop.",
+      "Use the browser page to navigate, click the Launch button, and type into the Search term field."
+    ].join(" "),
+    route: "auto",
+    workspaceRoot,
+    memoryDir,
+    bridge: new ScriptedReasoningBridge(scenario),
+    browserHeadless: true,
+    onEvent: (event) => {
+      events.push(event);
+    }
+  }).finally(async () => {
+    await stopBrowserSmokeServer(server.instance);
+  });
+
+  await verifySmokeArtifacts(workspaceRoot, events, result);
+
+  console.log("Phase 4 smoke passed.");
+  console.log(result);
+}
+
+function buildScenario(browserUrl: string): ScriptedBridgeScenario {
+  const plan = [
+    'Use write_file and read_file to create "smoke/local.txt" with "phase4 local smoke" and confirm the exact contents.',
+    'Use list_dir and run_shell to inspect the "smoke" directory and print the current working directory.',
+    `Use browser_navigate and browser_click to open ${browserUrl} and activate the "Launch" button.`,
+    'Use browser_type to enter "marshal smoke" into the Search term field.'
+  ];
+
+  return {
+    plan,
+    turnsByStep: {
+      [plan[0]]: [
+        {
+          kind: "action",
+          thought: "Create the smoke file inside the workspace sandbox.",
+          action: "write_file",
+          input: {
+            path: "smoke/local.txt",
+            content: "phase4 local smoke"
+          }
+        },
+        {
+          kind: "action",
+          thought: "Read the new smoke file to verify its contents.",
+          action: "read_file",
+          input: {
+            path: "smoke/local.txt"
+          }
+        },
+        {
+          kind: "final",
+          result: 'Created and verified "smoke/local.txt" with the expected content.'
+        }
+      ],
+      [plan[1]]: [
+        {
+          kind: "action",
+          thought: "List the smoke directory to confirm the file is present.",
+          action: "list_dir",
+          input: {
+            path: "smoke"
+          }
+        },
+        {
+          kind: "action",
+          thought: "Run a safe allowed shell command inside the workspace.",
+          action: "run_shell",
+          input: {
+            cmd: "pwd"
+          }
+        },
+        {
+          kind: "final",
+          result: "Printed the workspace current directory with run_shell."
+        }
+      ],
+      [plan[2]]: [
+        {
+          kind: "action",
+          thought: "Open the local browser smoke page over HTTP.",
+          action: "browser_navigate",
+          input: {
+            url: browserUrl
+          }
+        },
+        {
+          kind: "action",
+          thought: "Click the Launch button on the smoke page.",
+          action: "browser_click",
+          input: {
+            selector: "text=Launch"
+          }
+        },
+        {
+          kind: "final",
+          result: "Opened the local browser smoke page and clicked the Launch button."
+        }
+      ],
+      [plan[3]]: [
+        {
+          kind: "action",
+          thought: "Type into the smoke page input using its placeholder.",
+          action: "browser_type",
+          input: {
+            selector: "placeholder=Search term",
+            text: "marshal smoke"
+          }
+        },
+        {
+          kind: "final",
+          result: 'Typed "marshal smoke" into the Search term field.'
+        }
+      ]
+    },
+    finalResult:
+      "Phase 4 smoke validation succeeded across filesystem, shell, and browser tool paths through the agent loop."
+  };
+}
+
+async function verifySmokeArtifacts(
+  workspaceRoot: string,
+  events: MarshalRuntimeEvent[],
+  result: string
+): Promise<void> {
+  const smokeFile = path.join(workspaceRoot, "smoke", "local.txt");
+  const content = await fs.readFile(smokeFile, "utf8");
+  if (content !== "phase4 local smoke") {
+    throw new Error(`Unexpected smoke file content: ${content}`);
+  }
+
+  assertEvent(events, "tool_completed", "write_file");
+  assertEvent(events, "tool_completed", "read_file");
+  assertEvent(events, "tool_completed", "list_dir");
+  assertEvent(events, "tool_completed", "run_shell");
+  assertEvent(events, "tool_completed", "browser_navigate");
+  assertEvent(events, "tool_completed", "browser_click");
+  assertEvent(events, "tool_completed", "browser_type");
+
+  if (!result.includes("Phase 4 smoke validation succeeded")) {
+    throw new Error(`Unexpected final smoke result: ${result}`);
+  }
+}
+
+function assertEvent(events: MarshalRuntimeEvent[], type: "tool_completed", action: string): void {
+  const found = events.some((event) => event.type === type && "action" in event && event.action === action);
+  if (!found) {
+    throw new Error(`Missing ${type} event for ${action}.`);
+  }
+}
+
+async function startBrowserSmokeServer(): Promise<{ instance: http.Server; port: number }> {
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Phase 4 Browser Smoke</title>
+  </head>
+  <body>
+    <main>
+      <button id="launch" type="button" onclick="document.title='Launch Clicked'; document.getElementById('status').textContent='clicked';">
+        Launch
+      </button>
+      <label>
+        Query
+        <input id="query" placeholder="Search term" />
+      </label>
+      <p id="status">idle</p>
+    </main>
+  </body>
+</html>`;
+
+  const server = http.createServer((request, response) => {
+    if (!request.url || request.url === "/") {
+      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      response.end(html);
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    response.end("not found");
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to resolve smoke server port.");
+  }
+
+  return {
+    instance: server,
+    port: address.port
+  };
+}
+
+async function stopBrowserSmokeServer(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/dist/agent/bridge/scripted.js
+++ b/dist/agent/bridge/scripted.js
@@ -1,0 +1,52 @@
+export class ScriptedReasoningBridge {
+    scenario;
+    stepTurnCounts = new Map();
+    constructor(scenario) {
+        this.scenario = scenario;
+    }
+    async initialize() { }
+    async openLoginWindow() {
+        throw new Error("ScriptedReasoningBridge does not support login flows.");
+    }
+    async resetConversation() {
+        this.stepTurnCounts.clear();
+    }
+    async prime(_initialPrompt) { }
+    async ask(prompt) {
+        if (prompt.startsWith("Create a concise execution plan for the task below.")) {
+            return JSON.stringify({ steps: this.scenario.plan });
+        }
+        if (prompt.startsWith("RESULT:\n") || prompt.startsWith("FORMAT ERROR.") || prompt.startsWith("STEP COMPLETION BLOCKED.")) {
+            return "ACK";
+        }
+        const currentStep = readCurrentStep(prompt);
+        if (currentStep) {
+            const turns = this.scenario.turnsByStep[currentStep];
+            if (!turns) {
+                throw new Error(`No scripted turns configured for step: ${currentStep}`);
+            }
+            const currentTurn = this.stepTurnCounts.get(currentStep) ?? 0;
+            const turn = turns[currentTurn];
+            if (!turn) {
+                throw new Error(`No scripted turn ${currentTurn + 1} configured for step: ${currentStep}`);
+            }
+            this.stepTurnCounts.set(currentStep, currentTurn + 1);
+            return formatTurn(turn);
+        }
+        if (prompt.startsWith("Task: ") && prompt.includes("Return the final answer as:")) {
+            return `FINAL: ${this.scenario.finalResult}`;
+        }
+        throw new Error(`Unexpected prompt for ScriptedReasoningBridge:\n${prompt}`);
+    }
+    async close() { }
+}
+function readCurrentStep(prompt) {
+    const match = prompt.match(/Current plan step \(\d+\/\d+\): ([^\n]+)/);
+    return match?.[1]?.trim() || null;
+}
+function formatTurn(turn) {
+    if (turn.kind === "final") {
+        return `FINAL: ${turn.result}`;
+    }
+    return [`THOUGHT: ${turn.thought}`, `ACTION: ${turn.action}`, `INPUT: ${JSON.stringify(turn.input)}`].join("\n");
+}

--- a/dist/agent/runtime/marshal.js
+++ b/dist/agent/runtime/marshal.js
@@ -16,10 +16,10 @@ const ROUTE_TOOL_MAP = {
 };
 export async function runMarshalTask(options) {
     const route = options.route ?? "auto";
-    const bridge = createReasoningBridge({ projectName: options.chatProjectName });
+    const bridge = options.bridge ?? createReasoningBridge({ projectName: options.chatProjectName });
     const memory = new MemoryStore(options.memoryDir);
     const sandbox = new FileSandbox(options.workspaceRoot);
-    const browserManager = new PlaywrightBrowserManager(false);
+    const browserManager = new PlaywrightBrowserManager(options.browserHeadless ?? false);
     const allowedTools = ROUTE_TOOL_MAP[route];
     const task = buildExecutionTask(options.task, route, options.attachments ?? [], sandbox.root);
     try {

--- a/dist/agent/smoke/phase4.js
+++ b/dist/agent/smoke/phase4.js
@@ -1,0 +1,211 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { ScriptedReasoningBridge } from "../bridge/scripted.js";
+import { runMarshalTask } from "../runtime/marshal.js";
+async function main() {
+    const workspaceRoot = path.resolve(process.cwd(), "agent/workspace/phase4-smoke");
+    const memoryDir = path.resolve(process.cwd(), "agent/memory/phase4-smoke");
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+    await fs.rm(memoryDir, { recursive: true, force: true });
+    const server = await startBrowserSmokeServer();
+    const browserUrl = `http://127.0.0.1:${server.port}/`;
+    const events = [];
+    const scenario = buildScenario(browserUrl);
+    const result = await runMarshalTask({
+        task: [
+            "Run the Phase 4 smoke validation.",
+            "Exercise filesystem, shell, and browser tools through the normal agent loop.",
+            "Use the browser page to navigate, click the Launch button, and type into the Search term field."
+        ].join(" "),
+        route: "auto",
+        workspaceRoot,
+        memoryDir,
+        bridge: new ScriptedReasoningBridge(scenario),
+        browserHeadless: true,
+        onEvent: (event) => {
+            events.push(event);
+        }
+    }).finally(async () => {
+        await stopBrowserSmokeServer(server.instance);
+    });
+    await verifySmokeArtifacts(workspaceRoot, events, result);
+    console.log("Phase 4 smoke passed.");
+    console.log(result);
+}
+function buildScenario(browserUrl) {
+    const plan = [
+        'Use write_file and read_file to create "smoke/local.txt" with "phase4 local smoke" and confirm the exact contents.',
+        'Use list_dir and run_shell to inspect the "smoke" directory and print the current working directory.',
+        `Use browser_navigate and browser_click to open ${browserUrl} and activate the "Launch" button.`,
+        'Use browser_type to enter "marshal smoke" into the Search term field.'
+    ];
+    return {
+        plan,
+        turnsByStep: {
+            [plan[0]]: [
+                {
+                    kind: "action",
+                    thought: "Create the smoke file inside the workspace sandbox.",
+                    action: "write_file",
+                    input: {
+                        path: "smoke/local.txt",
+                        content: "phase4 local smoke"
+                    }
+                },
+                {
+                    kind: "action",
+                    thought: "Read the new smoke file to verify its contents.",
+                    action: "read_file",
+                    input: {
+                        path: "smoke/local.txt"
+                    }
+                },
+                {
+                    kind: "final",
+                    result: 'Created and verified "smoke/local.txt" with the expected content.'
+                }
+            ],
+            [plan[1]]: [
+                {
+                    kind: "action",
+                    thought: "List the smoke directory to confirm the file is present.",
+                    action: "list_dir",
+                    input: {
+                        path: "smoke"
+                    }
+                },
+                {
+                    kind: "action",
+                    thought: "Run a safe allowed shell command inside the workspace.",
+                    action: "run_shell",
+                    input: {
+                        cmd: "pwd"
+                    }
+                },
+                {
+                    kind: "final",
+                    result: "Printed the workspace current directory with run_shell."
+                }
+            ],
+            [plan[2]]: [
+                {
+                    kind: "action",
+                    thought: "Open the local browser smoke page over HTTP.",
+                    action: "browser_navigate",
+                    input: {
+                        url: browserUrl
+                    }
+                },
+                {
+                    kind: "action",
+                    thought: "Click the Launch button on the smoke page.",
+                    action: "browser_click",
+                    input: {
+                        selector: "text=Launch"
+                    }
+                },
+                {
+                    kind: "final",
+                    result: "Opened the local browser smoke page and clicked the Launch button."
+                }
+            ],
+            [plan[3]]: [
+                {
+                    kind: "action",
+                    thought: "Type into the smoke page input using its placeholder.",
+                    action: "browser_type",
+                    input: {
+                        selector: "placeholder=Search term",
+                        text: "marshal smoke"
+                    }
+                },
+                {
+                    kind: "final",
+                    result: 'Typed "marshal smoke" into the Search term field.'
+                }
+            ]
+        },
+        finalResult: "Phase 4 smoke validation succeeded across filesystem, shell, and browser tool paths through the agent loop."
+    };
+}
+async function verifySmokeArtifacts(workspaceRoot, events, result) {
+    const smokeFile = path.join(workspaceRoot, "smoke", "local.txt");
+    const content = await fs.readFile(smokeFile, "utf8");
+    if (content !== "phase4 local smoke") {
+        throw new Error(`Unexpected smoke file content: ${content}`);
+    }
+    assertEvent(events, "tool_completed", "write_file");
+    assertEvent(events, "tool_completed", "read_file");
+    assertEvent(events, "tool_completed", "list_dir");
+    assertEvent(events, "tool_completed", "run_shell");
+    assertEvent(events, "tool_completed", "browser_navigate");
+    assertEvent(events, "tool_completed", "browser_click");
+    assertEvent(events, "tool_completed", "browser_type");
+    if (!result.includes("Phase 4 smoke validation succeeded")) {
+        throw new Error(`Unexpected final smoke result: ${result}`);
+    }
+}
+function assertEvent(events, type, action) {
+    const found = events.some((event) => event.type === type && "action" in event && event.action === action);
+    if (!found) {
+        throw new Error(`Missing ${type} event for ${action}.`);
+    }
+}
+async function startBrowserSmokeServer() {
+    const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Phase 4 Browser Smoke</title>
+  </head>
+  <body>
+    <main>
+      <button id="launch" type="button" onclick="document.title='Launch Clicked'; document.getElementById('status').textContent='clicked';">
+        Launch
+      </button>
+      <label>
+        Query
+        <input id="query" placeholder="Search term" />
+      </label>
+      <p id="status">idle</p>
+    </main>
+  </body>
+</html>`;
+    const server = http.createServer((request, response) => {
+        if (!request.url || request.url === "/") {
+            response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+            response.end(html);
+            return;
+        }
+        response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+        response.end("not found");
+    });
+    await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+        throw new Error("Unable to resolve smoke server port.");
+    }
+    return {
+        instance: server,
+        port: address.port
+    };
+}
+async function stopBrowserSmokeServer(server) {
+    await new Promise((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+});

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -87,7 +87,7 @@ Checklist:
 - [x] Add workspace sandbox.
 - [x] Add restricted shell runner.
 - [x] Add browser tool wrapper.
-- [ ] Smoke-test each tool path against the live loop.
+- [x] Smoke-test each tool path against the live loop.
 
 ### Phase 5. Delivery Workflow
 
@@ -214,4 +214,4 @@ Checklist:
 
 ## Current Exit Criteria
 
-The project is not complete until Phases 4, 6, 7, 8, 9, 10, and 11 are closed with live validation, not only static implementation.
+The project is not complete until Phases 6, 7, 8, 9, 10, and 11 are closed with live validation, not only static implementation.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Current Stage
 
-- Active stage: `Phase 4. Tooling and Sandbox Validation`
+- Active stage: `Phase 6. End-to-End Acceptance`
 - Overall state: `In Progress`
 - Last updated: `2026-03-19`
 
@@ -11,15 +11,15 @@
 - `Phase 1. Repository Foundation`
 - `Phase 2. Core Agent Runtime`
 - `Phase 3. ChatGPT Bridge Hardening`
+- `Phase 4. Tooling and Sandbox Validation`
 - `Phase 5. Delivery Workflow`
 
 ## In-Progress Phases
 
-- `Phase 4. Tooling and Sandbox Validation`
+- `Phase 6. End-to-End Acceptance`
 
 ## Pending Phases
 
-- `Phase 6. End-to-End Acceptance`
 - `Phase 7. Andrii Session Launcher`
 - `Phase 8. Operator Web Console`
 - `Phase 9. Telegram Control Surface`
@@ -45,10 +45,10 @@
 - Operator tasks can include uploaded files, which are persisted into per-session workspaces.
 - Operator sessions can route tasks through `auto`, `local`, or `browser` execution modes.
 - A dedicated architecture and implementation plan now exists for the macOS menu bar app in `docs/MENUBAR_APP_PLAN.md`.
+- A deterministic Phase 4 smoke harness now validates filesystem, shell, and browser tool paths through the full agent loop.
 
 ## Open Issues
 
-- Phase 4 tool-path smoke validation is still required through the agent loop.
 - End-to-end acceptance remains open for filesystem, shell, browser, and multi-step tasks.
 - Live validation of the new `Andrii` launcher flow is still required.
 - Phase 8 still needs a live UI-driven run against a connected ChatGPT session with a real file attachment.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node index.ts",
     "operator": "npm run build && node dist/operator-main.js",
+    "smoke:phase4": "npm run build && node dist/agent/smoke/phase4.js",
     "typecheck": "tsc --noEmit",
     "build": "tsc -p tsconfig.json && node scripts/postbuild.mjs",
     "check": "npm run typecheck"


### PR DESCRIPTION
## Summary

This PR closes the remaining Phase 4 validation gap by adding a deterministic smoke harness that exercises Marshal's filesystem, shell, and browser tool paths through the normal agent loop.

The runtime previously had the core sandbox and tool wrappers in place, but the project plan and status still correctly called out that those paths had not yet been smoke-tested end to end through `runMarshalTask`. That meant Phase 4 was implemented in code but not actually proven by a repeatable run.

This change adds a scripted reasoning bridge for deterministic loop control, lets the runtime accept an injected bridge and configurable browser headless mode for test execution, and introduces a dedicated Phase 4 smoke runner that validates `write_file`, `read_file`, `list_dir`, `run_shell`, `browser_navigate`, `browser_click`, and `browser_type` in one repeatable pass. The smoke runner serves a local HTTP page, drives the normal tool stack against it, verifies emitted runtime events, and confirms written artifacts inside the workspace sandbox.

As a result, the repository now has an explicit `npm run smoke:phase4` validation path, and the project docs move the active stage forward from Phase 4 to Phase 6.

## User impact

Users should have higher confidence that the sandboxed local tools are not only implemented but also exercised together through the real loop machinery. This reduces the chance that a later refactor silently breaks one tool path while leaving static code in place.

## Root cause

Phase 4 had been built incrementally, but no deterministic loop-level harness existed to run all tool classes without depending on a live ChatGPT session for planning and step execution.

## Fix

The runtime now supports dependency injection for the reasoning bridge and browser headless mode. A new scripted bridge provides stable planner and step responses for smoke scenarios, and a dedicated Phase 4 smoke script spins up a local browser target, runs the full tool sequence, and asserts both runtime events and produced artifacts.

## Validation

I ran:

- `npm run check`
- `npm run build`
- `npm run smoke:phase4`
