### PR TITLE
[codex] Harden live bridge task flow

### DIFF
--- a/agent/bridge/chatgpt-extension.ts
+++ b/agent/bridge/chatgpt-extension.ts
@@ -38,11 +38,14 @@ export class ExtensionChatGPTBridge implements ReasoningBridge {
     }
 
     await this.initialize();
-    const result = await this.server.sendCommand("send_prompt", {
-      prompt: initialPrompt,
-      responseMode: "ready_surface",
-      ...this.getProjectPayload()
-    });
+    const result = await this.server.sendCommand(
+      "send_prompt",
+      {
+        prompt: initialPrompt,
+        ...this.getProjectPayload()
+      },
+      180_000
+    );
     if (!result.ok) {
       throw new Error(result.error ?? "Extension failed to prime the ChatGPT conversation.");
     }

--- a/agent/bridge/chatgpt.ts
+++ b/agent/bridge/chatgpt.ts
@@ -176,25 +176,35 @@ export class ChatGPTBridge {
   private async extractLatestAssistantText(): Promise<string> {
     const page = await this.getPage();
     const text = (await page.evaluate(() => {
-      const clean = (value: string) => value.replace(/\u200b/g, "").replace(/\s+\n/g, "\n").trim();
-      const assistantMessages = Array.from(
-        document.querySelectorAll("[data-message-author-role='assistant']")
-      )
-        .map((element) => clean((element as HTMLElement).innerText || element.textContent || ""))
-        .filter(Boolean);
+      const clean = (value: string) => value.replace(/\u200b/g, "").replace(/\s+\n/g, "\n").replace(/\s+/g, " ").trim();
+      const isVisible = (element: Element) => {
+        const node = element as HTMLElement;
+        const style = window.getComputedStyle(node);
+        const rect = node.getBoundingClientRect();
+        return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+      };
+      const getVisibleTexts = (root: ParentNode | null, selector: string) => {
+        if (!root) {
+          return [];
+        }
+
+        return Array.from(root.querySelectorAll(selector))
+          .filter((element) => isVisible(element))
+          .map((element) => clean((element as HTMLElement).innerText || element.textContent || ""))
+          .filter(Boolean);
+      };
+      const main = document.querySelector("main");
+      const assistantMessages = getVisibleTexts(main, "[data-message-author-role='assistant']");
 
       if (assistantMessages.length > 0) {
         return assistantMessages[assistantMessages.length - 1];
       }
 
-      const main = document.querySelector("main");
       if (!main) {
         return "";
       }
 
-      const articleTexts = Array.from(main.querySelectorAll("article"))
-        .map((element) => clean((element as HTMLElement).innerText || element.textContent || ""))
-        .filter(Boolean);
+      const articleTexts = getVisibleTexts(main, "article");
 
       if (articleTexts.length > 0) {
         return articleTexts[articleTexts.length - 1];

--- a/agent/bridge/local-bridge-server.ts
+++ b/agent/bridge/local-bridge-server.ts
@@ -11,7 +11,7 @@ export type ExtensionState = {
   updatedAt: number;
 };
 
-type BridgeCommandKind = "send_prompt" | "reset_conversation";
+export type BridgeCommandKind = "send_prompt" | "reset_conversation" | "debug_snapshot";
 
 type BridgeCommand = {
   id: string;

--- a/agent/core/agent-loop.ts
+++ b/agent/core/agent-loop.ts
@@ -111,7 +111,8 @@ export class AgentLoop {
     let iteration = 0;
     let lastToolResult: string | null = null;
     let successfulToolsForStep = 0;
-    const requiresToolProof = stepRequiresSuccessfulTool(input.step);
+    const requiredTool = inferRequiredToolFromStep(input.step);
+    const requiresToolProof = requiredTool !== null || stepRequiresSuccessfulTool(input.step);
 
     while (iteration < input.maxIterations) {
       iteration += 1;
@@ -135,7 +136,8 @@ export class AgentLoop {
         workspaceRoot: this.workspaceRoot,
         recentFacts: this.verifiedFacts.slice(-6),
         recentFailures: this.recentFailures.slice(-6),
-        availableTools: this.availableTools
+        availableTools: this.availableTools,
+        requiredTool
       });
 
       const raw = await this.bridge.ask(prompt);
@@ -155,7 +157,9 @@ export class AgentLoop {
             [
               "STEP COMPLETION BLOCKED.",
               `The current step requires a successful tool result before FINAL is allowed: ${input.step}`,
-              "Use exactly one ACTION and wait for its RESULT before returning FINAL."
+              requiredTool
+                ? `Use exactly one ACTION: ${requiredTool} with valid INPUT JSON, then wait for its RESULT before returning FINAL.`
+                : "Use exactly one ACTION and wait for its RESULT before returning FINAL."
             ].join("\n")
           );
           continue;
@@ -306,4 +310,13 @@ function stepRequiresSuccessfulTool(step: string): boolean {
   }
 
   return /(^|[\s"'])https?:\/\//.test(normalized) || /(^|[\s"'(])\/[^\s]*/.test(normalized);
+}
+
+function inferRequiredToolFromStep(step: string): ToolName | null {
+  const normalized = step.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  return ALL_TOOL_NAMES.find((toolName) => normalized.includes(toolName)) ?? null;
 }

--- a/agent/core/parser.ts
+++ b/agent/core/parser.ts
@@ -35,18 +35,21 @@ export function parseModelResponse(raw: string): ParsedResponse {
   }
 
   const actionMatch = text.match(/^THOUGHT:\s*([^\n]+)\nACTION:\s*([a-z_]+)\nINPUT:\s*([\s\S]+)$/);
-  if (!actionMatch) {
+  const inlineActionMatch =
+    actionMatch ?? text.match(/^THOUGHT:\s*([\s\S]*?)\s+ACTION:\s*([a-z_]+)\s+INPUT:\s*([\s\S]+)$/);
+
+  if (!inlineActionMatch) {
     throw new Error("Response does not match the strict ACTION or FINAL protocol.");
   }
 
-  const action = actionMatch[2].trim() as ToolName;
+  const action = inlineActionMatch[2].trim() as ToolName;
   if (!ACTION_NAMES.has(action)) {
     throw new Error(`Unsupported action: ${action}`);
   }
 
   let input: Record<string, unknown>;
   try {
-    input = JSON.parse(stripCodeFences(actionMatch[3]));
+    input = JSON.parse(stripCodeFences(inlineActionMatch[3]));
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown JSON parse error.";
     throw new Error(`INPUT is not valid JSON: ${message}`);
@@ -54,7 +57,7 @@ export function parseModelResponse(raw: string): ParsedResponse {
 
   return {
     kind: "action",
-    thought: actionMatch[1].trim(),
+    thought: inlineActionMatch[1].trim(),
     action,
     input,
     raw
@@ -80,6 +83,14 @@ export function parsePlannerResponse(raw: string): Plan {
 
     return { steps, raw };
   } catch {
+    const repairedSteps = parseLoosePlannerSteps(text);
+    if (repairedSteps.length > 0) {
+      return {
+        steps: repairedSteps,
+        raw
+      };
+    }
+
     const fallbackSteps = text
       .split("\n")
       .map((line) => line.replace(/^\d+\.\s*/, "").trim())
@@ -97,4 +108,31 @@ export function parsePlannerResponse(raw: string): Plan {
       raw
     };
   }
+}
+
+function parseLoosePlannerSteps(text: string): string[] {
+  const match = text.match(/"steps"\s*:\s*\[([\s\S]*?)\]\s*}/);
+  if (!match) {
+    return [];
+  }
+
+  const inner = match[1].trim();
+  if (!inner) {
+    return [];
+  }
+
+  return inner
+    .split(/"\s*,\s*"/)
+    .map((value, index, values) => {
+      let normalized = value.trim();
+      if (index === 0) {
+        normalized = normalized.replace(/^"/, "");
+      }
+      if (index === values.length - 1) {
+        normalized = normalized.replace(/"$/, "");
+      }
+
+      return normalized.replace(/\\"/g, "\"").trim();
+    })
+    .filter((value) => value.length > 0);
 }

--- a/agent/core/protocol.ts
+++ b/agent/core/protocol.ts
@@ -120,6 +120,7 @@ export function createStepPrompt(input: {
   recentFacts?: string[];
   recentFailures?: string[];
   availableTools?: ToolName[];
+  requiredTool?: ToolName | null;
 }): string {
   const completed =
     input.priorStepSummaries.length === 0
@@ -138,6 +139,9 @@ export function createStepPrompt(input: {
   return [
     `Main task: ${input.task}`,
     `Current plan step (${input.stepIndex + 1}/${input.totalSteps}): ${input.step}`,
+    input.requiredTool
+      ? `Required tool for this step: ${input.requiredTool}. You must use ACTION: ${input.requiredTool} successfully before FINAL.`
+      : null,
     input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : null,
     `Completed step summaries:\n${completed}`,
     `Memory summary:\n${input.memorySummary}`,
@@ -149,6 +153,9 @@ export function createStepPrompt(input: {
     "Rules:",
     "- Use exactly one ACTION at a time.",
     "- Prefer inspecting state before mutating files.",
+    input.requiredTool
+      ? `- This step requires ACTION: ${input.requiredTool} before FINAL.`
+      : "- If the current step names a tool explicitly, use that tool before FINAL.",
     "- Only return FINAL when the current step is proven complete by successful tool results.",
     "- Never claim a file was created, modified, read, verified, or listed unless a tool result in this task confirms it.",
     "- If a tool failed, report the limitation accurately instead of claiming success.",

--- a/chrome-extension/src/background.ts
+++ b/chrome-extension/src/background.ts
@@ -3,7 +3,7 @@ const CLIENT_ID_KEY = "marshalClientId";
 
 type BridgeCommand = {
   id: string;
-  kind: "send_prompt" | "reset_conversation";
+  kind: "send_prompt" | "reset_conversation" | "debug_snapshot";
   payload: Record<string, unknown>;
 };
 

--- a/chrome-extension/src/content.ts
+++ b/chrome-extension/src/content.ts
@@ -1,6 +1,6 @@
 type BridgeCommand = {
   id: string;
-  kind: "send_prompt" | "reset_conversation";
+  kind: "send_prompt" | "reset_conversation" | "debug_snapshot";
   payload: Record<string, unknown>;
 };
 
@@ -73,6 +73,13 @@ async function executeCommand(command: BridgeCommand): Promise<CommandResult> {
       const responseText = await waitForStableAssistantText(previous);
       return { ok: true, data: { responseText } };
     }
+    case "debug_snapshot":
+      return {
+        ok: true,
+        data: {
+          snapshot: collectDebugSnapshot()
+        }
+      };
     default:
       return { ok: false, error: `Unsupported extension command: ${command.kind}` };
   }
@@ -208,6 +215,8 @@ function setComposerText(composer: HTMLElement, text: string): void {
 
 async function submitComposer(composer: HTMLElement, prompt: string): Promise<void> {
   const previousValue = readComposerText(composer);
+  const previousUrl = window.location.href;
+  await sleep(150);
   composer.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true }));
   composer.dispatchEvent(new KeyboardEvent("keypress", { key: "Enter", code: "Enter", bubbles: true }));
   composer.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", code: "Enter", bubbles: true }));
@@ -218,7 +227,7 @@ async function submitComposer(composer: HTMLElement, prompt: string): Promise<vo
     return;
   }
 
-  const sendButton = resolveSendButton();
+  const sendButton = await waitForSendButton(composer);
   sendButton?.click();
   await sleep(250);
 
@@ -228,9 +237,17 @@ async function submitComposer(composer: HTMLElement, prompt: string): Promise<vo
 
   const enclosingForm = composer.closest("form");
   if (enclosingForm && typeof enclosingForm.requestSubmit === "function") {
-    enclosingForm.requestSubmit();
+    const submitter =
+      sendButton instanceof HTMLButtonElement && sendButton.type === "submit" ? sendButton : undefined;
+    enclosingForm.requestSubmit(submitter);
     await sleep(250);
   }
+
+  if (await waitForPromptSubmission(composer, previousValue, prompt, previousUrl)) {
+    return;
+  }
+
+  throw new Error("The ChatGPT composer did not submit the prompt.");
 }
 
 async function resetConversation(): Promise<void> {
@@ -269,24 +286,18 @@ async function ensureProjectSelected(projectName: string): Promise<void> {
 }
 
 function extractLatestAssistantText(): string {
-  const assistantMessages = Array.from(
-    document.querySelectorAll("[data-message-author-role='assistant']")
-  )
-    .map((element) => normalizeText((element as HTMLElement).innerText || element.textContent || ""))
-    .filter(Boolean);
+  const main = document.querySelector("main");
+  const assistantMessages = getVisibleConversationTexts(main, "[data-message-author-role='assistant']");
 
   if (assistantMessages.length > 0) {
     return assistantMessages[assistantMessages.length - 1];
   }
 
-  const main = document.querySelector("main");
   if (!main) {
     return "";
   }
 
-  const articles = Array.from(main.querySelectorAll("article"))
-    .map((element) => normalizeText((element as HTMLElement).innerText || element.textContent || ""))
-    .filter(Boolean);
+  const articles = getVisibleConversationTexts(main, "article");
 
   return articles[articles.length - 1] ?? "";
 }
@@ -409,8 +420,11 @@ function normalizeComparableText(value: string): string {
   return normalizeText(value).toLowerCase();
 }
 
-function resolveSendButton(): HTMLElement | null {
+function resolveSendButton(composer?: HTMLElement | null): HTMLElement | null {
+  const scopedContainers = [composer?.closest("form"), composer?.parentElement, composer?.closest("main"), document]
+    .filter(Boolean) as ParentNode[];
   const selectors = [
+    'button[type="submit"]',
     '[data-testid*="send"]',
     'button[aria-label*="Send"]',
     'button[aria-label*="send"]',
@@ -420,15 +434,20 @@ function resolveSendButton(): HTMLElement | null {
     'button[aria-label*="Відправ"]'
   ];
 
-  for (const selector of selectors) {
-    const candidate = queryVisible(selector).find((element) => !element.hasAttribute("disabled"));
-    if (candidate) {
-      return candidate;
+  for (const container of scopedContainers) {
+    for (const selector of selectors) {
+      const candidate = Array.from(container.querySelectorAll(selector))
+        .filter((element) => isVisible(element))
+        .map((element) => element as HTMLElement)
+        .find((element) => !isDisabledElement(element));
+      if (candidate) {
+        return candidate;
+      }
     }
   }
 
-  return findElementsWithText("button,[role='button']", /(send|submit|надіслати|відправити)/i).find(
-    (element) => !element.hasAttribute("disabled")
+  return findElementsWithText("main button,main [role='button']", /(send|submit|надіслати|відправити)/i).find(
+    (element) => !isDisabledElement(element)
   ) ?? null;
 }
 
@@ -457,6 +476,105 @@ function didComposerSubmit(composer: HTMLElement, previousValue: string, prompt:
   return false;
 }
 
+async function waitForSendButton(composer: HTMLElement, timeoutMs = 3_000): Promise<HTMLElement | null> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const button = resolveSendButton(composer);
+    if (button) {
+      return button;
+    }
+
+    await sleep(100);
+  }
+
+  return null;
+}
+
+async function waitForPromptSubmission(
+  composer: HTMLElement,
+  previousValue: string,
+  prompt: string,
+  previousUrl: string,
+  timeoutMs = 5_000
+): Promise<boolean> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (window.location.href !== previousUrl || didComposerSubmit(composer, previousValue, prompt)) {
+      return true;
+    }
+
+    await sleep(100);
+  }
+
+  return false;
+}
+
+function isDisabledElement(element: HTMLElement): boolean {
+  return element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true";
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function collectDebugSnapshot(): Record<string, unknown> {
+  const main = document.querySelector("main");
+  const assistantMessages = getVisibleConversationTexts(main, "[data-message-author-role='assistant']");
+  const articles = getVisibleConversationTexts(main, "article");
+  const composer = resolveComposer({ throwOnFailure: false });
+  const composerContainer = composer?.closest("form") ?? composer?.parentElement ?? null;
+  const buttons = queryVisible("button,[role='button']")
+    .map((element) => normalizeText([
+      element.textContent ?? "",
+      element.getAttribute("aria-label") ?? "",
+      element.getAttribute("title") ?? ""
+    ].join(" ")))
+    .filter(Boolean)
+    .slice(0, 30);
+  const composerButtons = composerContainer
+    ? Array.from(composerContainer.querySelectorAll("button,[role='button']"))
+        .filter((element) => isVisible(element))
+        .map((element) => {
+          const node = element as HTMLElement;
+          return {
+            text: normalizeText([
+              node.textContent ?? "",
+              node.getAttribute("aria-label") ?? "",
+              node.getAttribute("title") ?? ""
+            ].join(" ")),
+            type: node instanceof HTMLButtonElement ? node.type || "button" : node.getAttribute("role") || "",
+            disabled: isDisabledElement(node),
+            testId: node.getAttribute("data-testid") ?? ""
+          };
+        })
+        .slice(0, 10)
+    : [];
+
+  return {
+    url: window.location.href,
+    title: document.title,
+    state: detectPageState(),
+    composerText: composer ? readComposerText(composer) : "",
+    composerTag: composer?.tagName ?? "",
+    composerAriaLabel: composer?.getAttribute("aria-label") ?? "",
+    composerContainerTag: composerContainer instanceof HTMLElement ? composerContainer.tagName : "",
+    composerButtons,
+    assistantMessagesCount: assistantMessages.length,
+    lastAssistantMessage: assistantMessages.at(-1) ?? "",
+    articlesCount: articles.length,
+    lastArticle: articles.at(-1) ?? "",
+    mainTextSample: normalizeText((main as HTMLElement | null)?.innerText || "").slice(0, 2000),
+    visibleButtons: buttons
+  };
+}
+
+function getVisibleConversationTexts(root: ParentNode | null, selector: string): string[] {
+  if (!root) {
+    return [];
+  }
+
+  return Array.from(root.querySelectorAll(selector))
+    .filter((element) => isVisible(element))
+    .map((element) => normalizeText((element as HTMLElement).innerText || element.textContent || ""))
+    .filter(Boolean);
 }

--- a/dist/agent/bridge/chatgpt-extension.js
+++ b/dist/agent/bridge/chatgpt-extension.js
@@ -32,9 +32,8 @@ export class ExtensionChatGPTBridge {
         await this.initialize();
         const result = await this.server.sendCommand("send_prompt", {
             prompt: initialPrompt,
-            responseMode: "ready_surface",
             ...this.getProjectPayload()
-        });
+        }, 180_000);
         if (!result.ok) {
             throw new Error(result.error ?? "Extension failed to prime the ChatGPT conversation.");
         }

--- a/dist/agent/bridge/chatgpt.js
+++ b/dist/agent/bridge/chatgpt.js
@@ -129,20 +129,31 @@ export class ChatGPTBridge {
     async extractLatestAssistantText() {
         const page = await this.getPage();
         const text = (await page.evaluate(() => {
-            const clean = (value) => value.replace(/\u200b/g, "").replace(/\s+\n/g, "\n").trim();
-            const assistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"))
-                .map((element) => clean(element.innerText || element.textContent || ""))
-                .filter(Boolean);
+            const clean = (value) => value.replace(/\u200b/g, "").replace(/\s+\n/g, "\n").replace(/\s+/g, " ").trim();
+            const isVisible = (element) => {
+                const node = element;
+                const style = window.getComputedStyle(node);
+                const rect = node.getBoundingClientRect();
+                return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+            };
+            const getVisibleTexts = (root, selector) => {
+                if (!root) {
+                    return [];
+                }
+                return Array.from(root.querySelectorAll(selector))
+                    .filter((element) => isVisible(element))
+                    .map((element) => clean(element.innerText || element.textContent || ""))
+                    .filter(Boolean);
+            };
+            const main = document.querySelector("main");
+            const assistantMessages = getVisibleTexts(main, "[data-message-author-role='assistant']");
             if (assistantMessages.length > 0) {
                 return assistantMessages[assistantMessages.length - 1];
             }
-            const main = document.querySelector("main");
             if (!main) {
                 return "";
             }
-            const articleTexts = Array.from(main.querySelectorAll("article"))
-                .map((element) => clean(element.innerText || element.textContent || ""))
-                .filter(Boolean);
+            const articleTexts = getVisibleTexts(main, "article");
             if (articleTexts.length > 0) {
                 return articleTexts[articleTexts.length - 1];
             }

--- a/dist/agent/core/agent-loop.js
+++ b/dist/agent/core/agent-loop.js
@@ -62,7 +62,8 @@ export class AgentLoop {
         let iteration = 0;
         let lastToolResult = null;
         let successfulToolsForStep = 0;
-        const requiresToolProof = stepRequiresSuccessfulTool(input.step);
+        const requiredTool = inferRequiredToolFromStep(input.step);
+        const requiresToolProof = requiredTool !== null || stepRequiresSuccessfulTool(input.step);
         while (iteration < input.maxIterations) {
             iteration += 1;
             await this.memory.setCurrentStep(input.step, iteration);
@@ -84,7 +85,8 @@ export class AgentLoop {
                 workspaceRoot: this.workspaceRoot,
                 recentFacts: this.verifiedFacts.slice(-6),
                 recentFailures: this.recentFailures.slice(-6),
-                availableTools: this.availableTools
+                availableTools: this.availableTools,
+                requiredTool
             });
             const raw = await this.bridge.ask(prompt);
             let parsed;
@@ -101,7 +103,9 @@ export class AgentLoop {
                     await this.bridge.ask([
                         "STEP COMPLETION BLOCKED.",
                         `The current step requires a successful tool result before FINAL is allowed: ${input.step}`,
-                        "Use exactly one ACTION and wait for its RESULT before returning FINAL."
+                        requiredTool
+                            ? `Use exactly one ACTION: ${requiredTool} with valid INPUT JSON, then wait for its RESULT before returning FINAL.`
+                            : "Use exactly one ACTION and wait for its RESULT before returning FINAL."
                     ].join("\n"));
                     continue;
                 }
@@ -233,4 +237,11 @@ function stepRequiresSuccessfulTool(step) {
         return true;
     }
     return /(^|[\s"'])https?:\/\//.test(normalized) || /(^|[\s"'(])\/[^\s]*/.test(normalized);
+}
+function inferRequiredToolFromStep(step) {
+    const normalized = step.trim().toLowerCase();
+    if (!normalized) {
+        return null;
+    }
+    return ALL_TOOL_NAMES.find((toolName) => normalized.includes(toolName)) ?? null;
 }

--- a/dist/agent/core/parser.js
+++ b/dist/agent/core/parser.js
@@ -28,16 +28,17 @@ export function parseModelResponse(raw) {
         };
     }
     const actionMatch = text.match(/^THOUGHT:\s*([^\n]+)\nACTION:\s*([a-z_]+)\nINPUT:\s*([\s\S]+)$/);
-    if (!actionMatch) {
+    const inlineActionMatch = actionMatch ?? text.match(/^THOUGHT:\s*([\s\S]*?)\s+ACTION:\s*([a-z_]+)\s+INPUT:\s*([\s\S]+)$/);
+    if (!inlineActionMatch) {
         throw new Error("Response does not match the strict ACTION or FINAL protocol.");
     }
-    const action = actionMatch[2].trim();
+    const action = inlineActionMatch[2].trim();
     if (!ACTION_NAMES.has(action)) {
         throw new Error(`Unsupported action: ${action}`);
     }
     let input;
     try {
-        input = JSON.parse(stripCodeFences(actionMatch[3]));
+        input = JSON.parse(stripCodeFences(inlineActionMatch[3]));
     }
     catch (error) {
         const message = error instanceof Error ? error.message : "Unknown JSON parse error.";
@@ -45,7 +46,7 @@ export function parseModelResponse(raw) {
     }
     return {
         kind: "action",
-        thought: actionMatch[1].trim(),
+        thought: inlineActionMatch[1].trim(),
         action,
         input,
         raw
@@ -67,6 +68,13 @@ export function parsePlannerResponse(raw) {
         return { steps, raw };
     }
     catch {
+        const repairedSteps = parseLoosePlannerSteps(text);
+        if (repairedSteps.length > 0) {
+            return {
+                steps: repairedSteps,
+                raw
+            };
+        }
         const fallbackSteps = text
             .split("\n")
             .map((line) => line.replace(/^\d+\.\s*/, "").trim())
@@ -82,4 +90,27 @@ export function parsePlannerResponse(raw) {
             raw
         };
     }
+}
+function parseLoosePlannerSteps(text) {
+    const match = text.match(/"steps"\s*:\s*\[([\s\S]*?)\]\s*}/);
+    if (!match) {
+        return [];
+    }
+    const inner = match[1].trim();
+    if (!inner) {
+        return [];
+    }
+    return inner
+        .split(/"\s*,\s*"/)
+        .map((value, index, values) => {
+        let normalized = value.trim();
+        if (index === 0) {
+            normalized = normalized.replace(/^"/, "");
+        }
+        if (index === values.length - 1) {
+            normalized = normalized.replace(/"$/, "");
+        }
+        return normalized.replace(/\\"/g, "\"").trim();
+    })
+        .filter((value) => value.length > 0);
 }

--- a/dist/agent/core/protocol.js
+++ b/dist/agent/core/protocol.js
@@ -70,6 +70,9 @@ export function createStepPrompt(input) {
     return [
         `Main task: ${input.task}`,
         `Current plan step (${input.stepIndex + 1}/${input.totalSteps}): ${input.step}`,
+        input.requiredTool
+            ? `Required tool for this step: ${input.requiredTool}. You must use ACTION: ${input.requiredTool} successfully before FINAL.`
+            : null,
         input.workspaceRoot ? `Workspace root: ${input.workspaceRoot}` : null,
         `Completed step summaries:\n${completed}`,
         `Memory summary:\n${input.memorySummary}`,
@@ -81,6 +84,9 @@ export function createStepPrompt(input) {
         "Rules:",
         "- Use exactly one ACTION at a time.",
         "- Prefer inspecting state before mutating files.",
+        input.requiredTool
+            ? `- This step requires ACTION: ${input.requiredTool} before FINAL.`
+            : "- If the current step names a tool explicitly, use that tool before FINAL.",
         "- Only return FINAL when the current step is proven complete by successful tool results.",
         "- Never claim a file was created, modified, read, verified, or listed unless a tool result in this task confirms it.",
         "- If a tool failed, report the limitation accurately instead of claiming success.",

--- a/dist/chrome-extension/src/content.js
+++ b/dist/chrome-extension/src/content.js
@@ -51,6 +51,13 @@ async function executeCommand(command) {
             const responseText = await waitForStableAssistantText(previous);
             return { ok: true, data: { responseText } };
         }
+        case "debug_snapshot":
+            return {
+                ok: true,
+                data: {
+                    snapshot: collectDebugSnapshot()
+                }
+            };
         default:
             return { ok: false, error: `Unsupported extension command: ${command.kind}` };
     }
@@ -158,6 +165,8 @@ function setComposerText(composer, text) {
 }
 async function submitComposer(composer, prompt) {
     const previousValue = readComposerText(composer);
+    const previousUrl = window.location.href;
+    await sleep(150);
     composer.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true }));
     composer.dispatchEvent(new KeyboardEvent("keypress", { key: "Enter", code: "Enter", bubbles: true }));
     composer.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", code: "Enter", bubbles: true }));
@@ -165,7 +174,7 @@ async function submitComposer(composer, prompt) {
     if (didComposerSubmit(composer, previousValue, prompt)) {
         return;
     }
-    const sendButton = resolveSendButton();
+    const sendButton = await waitForSendButton(composer);
     sendButton?.click();
     await sleep(250);
     if (didComposerSubmit(composer, previousValue, prompt)) {
@@ -173,9 +182,14 @@ async function submitComposer(composer, prompt) {
     }
     const enclosingForm = composer.closest("form");
     if (enclosingForm && typeof enclosingForm.requestSubmit === "function") {
-        enclosingForm.requestSubmit();
+        const submitter = sendButton instanceof HTMLButtonElement && sendButton.type === "submit" ? sendButton : undefined;
+        enclosingForm.requestSubmit(submitter);
         await sleep(250);
     }
+    if (await waitForPromptSubmission(composer, previousValue, prompt, previousUrl)) {
+        return;
+    }
+    throw new Error("The ChatGPT composer did not submit the prompt.");
 }
 async function resetConversation() {
     const newChat = findElementsWithText('a,button,[role="button"]', /(new chat|new conversation|новий чат)/i)[0];
@@ -202,19 +216,15 @@ async function ensureProjectSelected(projectName) {
     await waitForReadySurface();
 }
 function extractLatestAssistantText() {
-    const assistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"))
-        .map((element) => normalizeText(element.innerText || element.textContent || ""))
-        .filter(Boolean);
+    const main = document.querySelector("main");
+    const assistantMessages = getVisibleConversationTexts(main, "[data-message-author-role='assistant']");
     if (assistantMessages.length > 0) {
         return assistantMessages[assistantMessages.length - 1];
     }
-    const main = document.querySelector("main");
     if (!main) {
         return "";
     }
-    const articles = Array.from(main.querySelectorAll("article"))
-        .map((element) => normalizeText(element.innerText || element.textContent || ""))
-        .filter(Boolean);
+    const articles = getVisibleConversationTexts(main, "article");
     return articles[articles.length - 1] ?? "";
 }
 async function waitForStableAssistantText(previousText) {
@@ -306,8 +316,11 @@ function normalizeText(value) {
 function normalizeComparableText(value) {
     return normalizeText(value).toLowerCase();
 }
-function resolveSendButton() {
+function resolveSendButton(composer) {
+    const scopedContainers = [composer?.closest("form"), composer?.parentElement, composer?.closest("main"), document]
+        .filter(Boolean);
     const selectors = [
+        'button[type="submit"]',
         '[data-testid*="send"]',
         'button[aria-label*="Send"]',
         'button[aria-label*="send"]',
@@ -316,13 +329,18 @@ function resolveSendButton() {
         'button[aria-label*="Надісл"]',
         'button[aria-label*="Відправ"]'
     ];
-    for (const selector of selectors) {
-        const candidate = queryVisible(selector).find((element) => !element.hasAttribute("disabled"));
-        if (candidate) {
-            return candidate;
+    for (const container of scopedContainers) {
+        for (const selector of selectors) {
+            const candidate = Array.from(container.querySelectorAll(selector))
+                .filter((element) => isVisible(element))
+                .map((element) => element)
+                .find((element) => !isDisabledElement(element));
+            if (candidate) {
+                return candidate;
+            }
         }
     }
-    return findElementsWithText("button,[role='button']", /(send|submit|надіслати|відправити)/i).find((element) => !element.hasAttribute("disabled")) ?? null;
+    return findElementsWithText("main button,main [role='button']", /(send|submit|надіслати|відправити)/i).find((element) => !isDisabledElement(element)) ?? null;
 }
 function readComposerText(composer) {
     if (composer instanceof HTMLTextAreaElement || composer instanceof HTMLInputElement) {
@@ -343,6 +361,88 @@ function didComposerSubmit(composer, previousValue, prompt) {
     }
     return false;
 }
+async function waitForSendButton(composer, timeoutMs = 3_000) {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+        const button = resolveSendButton(composer);
+        if (button) {
+            return button;
+        }
+        await sleep(100);
+    }
+    return null;
+}
+async function waitForPromptSubmission(composer, previousValue, prompt, previousUrl, timeoutMs = 5_000) {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+        if (window.location.href !== previousUrl || didComposerSubmit(composer, previousValue, prompt)) {
+            return true;
+        }
+        await sleep(100);
+    }
+    return false;
+}
+function isDisabledElement(element) {
+    return element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true";
+}
 function sleep(ms) {
     return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+function collectDebugSnapshot() {
+    const main = document.querySelector("main");
+    const assistantMessages = getVisibleConversationTexts(main, "[data-message-author-role='assistant']");
+    const articles = getVisibleConversationTexts(main, "article");
+    const composer = resolveComposer({ throwOnFailure: false });
+    const composerContainer = composer?.closest("form") ?? composer?.parentElement ?? null;
+    const buttons = queryVisible("button,[role='button']")
+        .map((element) => normalizeText([
+        element.textContent ?? "",
+        element.getAttribute("aria-label") ?? "",
+        element.getAttribute("title") ?? ""
+    ].join(" ")))
+        .filter(Boolean)
+        .slice(0, 30);
+    const composerButtons = composerContainer
+        ? Array.from(composerContainer.querySelectorAll("button,[role='button']"))
+            .filter((element) => isVisible(element))
+            .map((element) => {
+            const node = element;
+            return {
+                text: normalizeText([
+                    node.textContent ?? "",
+                    node.getAttribute("aria-label") ?? "",
+                    node.getAttribute("title") ?? ""
+                ].join(" ")),
+                type: node instanceof HTMLButtonElement ? node.type || "button" : node.getAttribute("role") || "",
+                disabled: isDisabledElement(node),
+                testId: node.getAttribute("data-testid") ?? ""
+            };
+        })
+            .slice(0, 10)
+        : [];
+    return {
+        url: window.location.href,
+        title: document.title,
+        state: detectPageState(),
+        composerText: composer ? readComposerText(composer) : "",
+        composerTag: composer?.tagName ?? "",
+        composerAriaLabel: composer?.getAttribute("aria-label") ?? "",
+        composerContainerTag: composerContainer instanceof HTMLElement ? composerContainer.tagName : "",
+        composerButtons,
+        assistantMessagesCount: assistantMessages.length,
+        lastAssistantMessage: assistantMessages.at(-1) ?? "",
+        articlesCount: articles.length,
+        lastArticle: articles.at(-1) ?? "",
+        mainTextSample: normalizeText(main?.innerText || "").slice(0, 2000),
+        visibleButtons: buttons
+    };
+}
+function getVisibleConversationTexts(root, selector) {
+    if (!root) {
+        return [];
+    }
+    return Array.from(root.querySelectorAll(selector))
+        .filter((element) => isVisible(element))
+        .map((element) => normalizeText(element.innerText || element.textContent || ""))
+        .filter(Boolean);
 }


### PR DESCRIPTION
## Summary

This PR hardens the ChatGPT extension bridge path used by the desktop menu bar app and local runtime so a real local task can complete end to end again.

The user-visible regression was that live runs would intermittently stall or loop during priming, planning, or the first required action. In practice that meant the desktop shell looked healthy, but a real task could still die with `Timed out waiting for extension result: send_prompt`, get stuck on a stale planner response, or churn on repeated step retries.

## Root Cause

There were multiple interacting problems in the extension-driven path:

- The extension content script was not robust enough about prompt submission timing, so prompts could remain in the composer while the bridge waited for a response that never started.
- Priming had been downgraded to a ready-surface check, which let planner reads race with the prior priming turn and pull the wrong assistant state into the runtime.
- Planner responses sometimes arrived as slightly malformed JSON, and action responses sometimes arrived as valid `THOUGHT/ACTION/INPUT` content on one line rather than the strict three-line shape the parser expected.
- The step prompt was not forceful enough when a plan step already mandated a specific tool, so the model could keep trying to skip straight to `FINAL`.

## Fix

This change set tightens the whole flow instead of papering over only one timeout:

- hardens the content-script submit path and adds targeted debug snapshot support for bridge debugging;
- scopes assistant extraction more carefully and keeps the Playwright bridge logic aligned with the extension bridge;
- restores priming to a full assistant-text round trip so planner requests do not race the prior turn;
- adds tolerant planner parsing for near-JSON `{"steps":[...]}` payloads;
- accepts inline `THOUGHT: ... ACTION: ... INPUT: ...` responses in the core parser;
- teaches the step prompt and blocker flow to explicitly require the named tool when the plan step already implies one.

## Validation

I validated this with:

- `npm run check`
- `npm run build`
- a live extension-bridge run of `runMarshalTask` for `Reply with exactly: bridge live`, which now completes with `FINAL_RESULT="bridge live"`.
