### PR TITLE
feat(updater): in-app auto-install instead of manual DMG download

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# menubar@9.5.2 declares a peer dep of electron@">=9.0.0 <35.0.0" but we run
+# on electron 41. npm <=10 refuses npm ci under that conflict; package-lock.json
+# already encodes a working resolution. legacy-peer-deps tells npm to treat
+# the lock as authoritative and skip the peer-dep solver entirely. Drop this
+# file when menubar is replaced or its peer-dep range catches up (#tbd).
+legacy-peer-deps=true

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -13,6 +13,8 @@ import { CaptureHistoryWindow } from "./capture/capture-history-window.ts";
 import { FloatingToolbar } from "./capture/floating-toolbar.ts";
 import { ScrollCapture } from "./capture/scroll-capture.ts";
 import { UpdateChecker, type UpdateCheckOutcome } from "./updater/update-checker.ts";
+import { UpdateInstaller, type InstallProgress } from "./updater/update-installer.ts";
+import { planSwap } from "./updater/swap-planner.ts";
 import { runCountdown } from "./capture/countdown-window.ts";
 import { pickArea } from "./capture/area-picker.ts";
 import { RecordingIndicator } from "./capture/recording-indicator.ts";
@@ -227,6 +229,7 @@ function registerIpcHandlers(): void {
   handleIpc("marshal:get-settings", () => loadSettings());
   handleIpc("marshal:check-for-updates", () => runManualUpdateCheck());
   handleIpc("marshal:check-for-updates-silent", () => runSilentUpdateCheck());
+  handleIpc("marshal:start-update-install", (event) => runUpdateInstall(event.sender));
   handleIpc("marshal:open-external", (_event, url: string) => {
     if (typeof url !== "string" || !/^https?:\/\//u.test(url)) {
       throw new Error("Refused to open non-http URL");
@@ -799,6 +802,58 @@ async function runSilentUpdateCheck(): Promise<UpdateCheckOutcome | { error: str
     return { error: "Update checker is not running in this build." };
   }
   return updateChecker.check();
+}
+
+/**
+ * Drive the full in-app install: re-check (to pull fresh asset metadata),
+ * plan the swap, download + verify + extract, then spawn the post-quit script
+ * and quit. Progress events are forwarded to the calling renderer via the
+ * `marshal:update-install-progress` channel.
+ *
+ * Throws on any failure so the renderer can surface the error inline.
+ */
+async function runUpdateInstall(sender: Electron.WebContents): Promise<{ ok: true; version: string }> {
+  if (!updateChecker) {
+    throw new Error("Update checker is not running in this build.");
+  }
+  const result = await updateChecker.check();
+  if ("error" in result) {
+    throw new Error(result.error);
+  }
+  if (!result.available) {
+    throw new Error(`Already on the latest version (v${result.currentVersion}).`);
+  }
+  if (!result.installable) {
+    throw new Error(
+      "This release has no installable ZIP metadata (latest-mac.yml missing). " +
+        "Open the release page and install manually."
+    );
+  }
+
+  const decision = planSwap({ execPath: process.execPath });
+  if (!decision.ok) {
+    throw new Error(decision.refusal.detail);
+  }
+
+  const installer = new UpdateInstaller();
+  const forward = (p: InstallProgress) => {
+    if (sender.isDestroyed()) return;
+    sender.send("marshal:update-install-progress", p);
+  };
+  const dispose = installer.onProgress(forward);
+  try {
+    const prepared = await installer.prepare(result.installable, decision.plan);
+    installer.commit(prepared);
+    // Give the renderer a tick to render the "Relaunching…" state before we
+    // tear down the window.
+    setTimeout(() => {
+      isQuitting = true;
+      app.quit();
+    }, 250);
+    return { ok: true, version: result.installable.version };
+  } finally {
+    dispose();
+  }
 }
 
 async function showUpdateDialog(result: UpdateCheckOutcome): Promise<void> {

--- a/desktop/preload.cts
+++ b/desktop/preload.cts
@@ -111,10 +111,65 @@ const desktopApi = {
   getDictationDefaults: () => ipcRenderer.invoke("marshal:get-dictation-defaults") as Promise<{ prompt: string }>,
   checkForUpdatesSilent: () => ipcRenderer.invoke("marshal:check-for-updates-silent") as Promise<
     | { available: false; error: string }
-    | { available: false; currentVersion: string; latestVersion: string; releaseUrl: string; downloadUrl: string | null; releaseNotes: string }
-    | { available: true; currentVersion: string; latestVersion: string; releaseUrl: string; downloadUrl: string | null; releaseNotes: string }
+    | {
+        available: false;
+        currentVersion: string;
+        latestVersion: string;
+        releaseUrl: string;
+        downloadUrl: string | null;
+        releaseNotes: string;
+        installable: { zipUrl: string; sha512: string; size: number; version: string } | null;
+      }
+    | {
+        available: true;
+        currentVersion: string;
+        latestVersion: string;
+        releaseUrl: string;
+        downloadUrl: string | null;
+        releaseNotes: string;
+        installable: { zipUrl: string; sha512: string; size: number; version: string } | null;
+      }
     | { error: string }
   >,
+  startUpdateInstall: () =>
+    ipcRenderer.invoke("marshal:start-update-install") as Promise<{ ok: true; version: string }>,
+  onUpdateInstallProgress: (
+    cb: (
+      event: IpcRendererEvent,
+      payload: {
+        phase:
+          | "starting"
+          | "downloading"
+          | "verifying"
+          | "extracting"
+          | "staging"
+          | "relaunching"
+          | "done"
+          | "error";
+        ratio: number;
+        message?: string;
+        bytesDownloaded?: number;
+        bytesTotal?: number;
+      }
+    ) => void
+  ) =>
+    registerListener<[
+      {
+        phase:
+          | "starting"
+          | "downloading"
+          | "verifying"
+          | "extracting"
+          | "staging"
+          | "relaunching"
+          | "done"
+          | "error";
+        ratio: number;
+        message?: string;
+        bytesDownloaded?: number;
+        bytesTotal?: number;
+      }
+    ]>("marshal:update-install-progress", cb),
   openExternal: (url: string) => ipcRenderer.invoke("marshal:open-external", url) as Promise<{ ok: true }>
 };
 

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -1107,18 +1107,141 @@ function renderUpdateResult(result) {
   }
 
   out.classList.add("is-available");
-  const url = result.downloadUrl || result.releaseUrl;
+  const fallbackUrl = result.downloadUrl || result.releaseUrl;
   const notes = (result.releaseNotes ?? "").trim();
+  const canInstall = Boolean(result.installable);
+
+  const installButton = canInstall
+    ? `<button type="button" class="btn btn-primary" data-update-install>Download &amp; install</button>`
+    : "";
+  const releasePageLinkClass = canInstall ? "btn-secondary-link" : "btn btn-primary";
+  const releasePageLinkLabel = canInstall ? "Open release page" : "Download";
+
   out.innerHTML = `
     <div class="update-result-row">
       <span class="title">Marshal v${escapeHtml(result.latestVersion)} is available <span style="color:var(--text-muted);font-weight:400;">(you have v${escapeHtml(result.currentVersion)})</span></span>
-      <button type="button" class="btn btn-primary" data-update-download>Download</button>
+      <div class="update-result-actions">
+        ${installButton}
+        <button type="button" class="${releasePageLinkClass}" data-update-release-page>${releasePageLinkLabel}</button>
+      </div>
     </div>
     ${notes ? `<div class="update-result-notes">${escapeHtml(notes)}</div>` : ""}
   `;
-  out.querySelector("[data-update-download]")?.addEventListener("click", () => {
-    void api.openExternal?.(url);
+  out.querySelector("[data-update-release-page]")?.addEventListener("click", () => {
+    void api.openExternal?.(fallbackUrl);
   });
+  out.querySelector("[data-update-install]")?.addEventListener("click", () => {
+    void startInPlaceInstall(result);
+  });
+}
+
+// Map of internal install phases → user-facing labels.
+const UPDATE_PHASE_LABELS = {
+  starting: "Preparing…",
+  downloading: "Downloading…",
+  verifying: "Verifying signature…",
+  extracting: "Unpacking…",
+  staging: "Staging install…",
+  relaunching: "Relaunching Marshal…",
+  done: "Done.",
+  error: "Failed."
+};
+
+let updateInstallDisposer = null;
+
+async function startInPlaceInstall(result) {
+  const out = dom.settingsUpdateResult;
+  if (!out || !api?.startUpdateInstall) return;
+
+  // Drop the action buttons immediately so the user can't double-click.
+  out.classList.remove("is-error");
+  out.classList.add("is-available");
+  out.innerHTML = `
+    <div class="update-result-row">
+      <span class="title">Installing Marshal v${escapeHtml(result.latestVersion)}…</span>
+    </div>
+    <div class="update-progress">
+      <div class="update-progress-bar is-indeterminate"><div class="update-progress-bar-fill"></div></div>
+      <div class="update-progress-label">
+        <span data-update-phase>Preparing…</span>
+        <span data-update-detail></span>
+      </div>
+    </div>
+  `;
+
+  const bar = out.querySelector(".update-progress-bar");
+  const fill = out.querySelector(".update-progress-bar-fill");
+  const phaseEl = out.querySelector("[data-update-phase]");
+  const detailEl = out.querySelector("[data-update-detail]");
+
+  if (typeof updateInstallDisposer === "function") {
+    updateInstallDisposer();
+    updateInstallDisposer = null;
+  }
+  updateInstallDisposer = api.onUpdateInstallProgress?.((_event, payload) => {
+    if (!payload) return;
+    phaseEl.textContent = UPDATE_PHASE_LABELS[payload.phase] ?? payload.phase;
+    if (Number.isFinite(payload.ratio) && payload.ratio >= 0 && payload.ratio <= 1) {
+      bar.classList.remove("is-indeterminate");
+      fill.style.width = `${Math.round(payload.ratio * 100)}%`;
+    } else {
+      bar.classList.add("is-indeterminate");
+    }
+    if (payload.phase === "downloading" && payload.bytesTotal) {
+      detailEl.textContent = `${formatBytes(payload.bytesDownloaded ?? 0)} / ${formatBytes(payload.bytesTotal)}`;
+    } else if (payload.message) {
+      detailEl.textContent = payload.message;
+    } else {
+      detailEl.textContent = "";
+    }
+  });
+
+  try {
+    await api.startUpdateInstall();
+    // The main process spawns the post-quit script and triggers app.quit().
+    // We won't actually get here in practice — the window goes away first —
+    // but if the quit is somehow delayed, show a friendly "relaunching" state.
+    phaseEl.textContent = UPDATE_PHASE_LABELS.relaunching;
+    bar.classList.remove("is-indeterminate");
+    fill.style.width = "100%";
+    detailEl.textContent = "";
+  } catch (err) {
+    out.classList.remove("is-available");
+    out.classList.add("is-error");
+    const message = err?.message ?? String(err);
+    out.innerHTML = `
+      <div class="update-result-row">
+        <span class="title">Install failed: ${escapeHtml(message)}</span>
+        <div class="update-result-actions">
+          <button type="button" class="btn btn-secondary" data-update-retry>Try again</button>
+          <button type="button" class="btn-secondary-link" data-update-release-page>Open release page</button>
+        </div>
+      </div>
+    `;
+    out.querySelector("[data-update-retry]")?.addEventListener("click", () => {
+      void startInPlaceInstall(result);
+    });
+    out.querySelector("[data-update-release-page]")?.addEventListener("click", () => {
+      void api.openExternal?.(result.downloadUrl || result.releaseUrl);
+    });
+  } finally {
+    if (typeof updateInstallDisposer === "function") {
+      updateInstallDisposer();
+      updateInstallDisposer = null;
+    }
+  }
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value >= 100 || unit === 0 ? 0 : 1)} ${units[unit]}`;
 }
 
 // ── Init ──

--- a/desktop/renderer/styles.css
+++ b/desktop/renderer/styles.css
@@ -895,6 +895,62 @@ a:hover {
   max-height: 120px;
   overflow-y: auto;
 }
+.update-result-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.update-result-actions .btn-secondary-link {
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+.update-result-actions .btn-secondary-link:hover {
+  color: var(--text-default);
+}
+.update-progress {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.update-progress-bar {
+  position: relative;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg-muted);
+  overflow: hidden;
+  border: 1px solid var(--border-default);
+}
+.update-progress-bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0%;
+  background: var(--accent);
+  transition: width 0.15s linear;
+}
+.update-progress-bar.is-indeterminate .update-progress-bar-fill {
+  width: 35%;
+  animation: marshal-progress-indeterminate 1.4s ease-in-out infinite;
+}
+@keyframes marshal-progress-indeterminate {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(285%); }
+}
+.update-progress-label {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+.update-result.is-error .update-progress-bar-fill {
+  background: #dc2626;
+}
 
 .field-hint code {
   font-family: var(--font-mono);

--- a/desktop/updater/swap-planner.ts
+++ b/desktop/updater/swap-planner.ts
@@ -1,0 +1,126 @@
+// desktop/updater/swap-planner.ts
+//
+// Pure helper that figures out whether (and where) we are allowed to swap the
+// running Marshal.app bundle. Kept dependency-free so the rules are unit-
+// testable without spinning up Electron.
+//
+// The single export `planSwap` answers two questions:
+//
+//   1. Is the currently running process inside a real, writable .app bundle
+//      that lives somewhere we can replace? (i.e. NOT dev-mode Electron, NOT
+//      a read-only `/Volumes/` mount.)
+//   2. If yes, what are the paths the post-quit shell script needs?
+//
+// The installer (`./update-installer.ts`) calls this once, refuses on a `no`,
+// and feeds the plan into the detached swap script otherwise.
+
+import path from "node:path";
+
+export interface SwapPlan {
+  /** Absolute path to the running .app bundle (e.g. /Applications/Marshal.app). */
+  currentAppPath: string;
+  /** Parent directory of the .app bundle — the script swaps inside this dir. */
+  installDir: string;
+  /** Bundle filename (`Marshal.app`) — pinned so the new bundle lands at the same name. */
+  appName: string;
+}
+
+export interface SwapRefusal {
+  reason:
+    | "not-packaged"
+    | "read-only-volume"
+    | "unknown-layout";
+  detail: string;
+}
+
+export type SwapDecision =
+  | { ok: true; plan: SwapPlan }
+  | { ok: false; refusal: SwapRefusal };
+
+export interface PlanInput {
+  /** `process.execPath` from the main process. */
+  execPath: string;
+  /** Set this to skip the "dev mode" check during automated tests. */
+  bypassDevCheck?: boolean;
+}
+
+/**
+ * Decide whether we can swap the current bundle.
+ *
+ * `execPath` is expected to look like:
+ *   /Applications/Marshal.app/Contents/MacOS/Marshal
+ *
+ * We walk parents looking for a `*.app` segment, then refuse if the bundle is
+ * Electron itself (dev) or lives on a `/Volumes/` mount (DMG / external).
+ */
+export function planSwap(input: PlanInput): SwapDecision {
+  const execPath = input.execPath;
+  const appBundlePath = findAppBundleAncestor(execPath);
+  if (!appBundlePath) {
+    return {
+      ok: false,
+      refusal: {
+        reason: "not-packaged",
+        detail: `execPath has no .app ancestor (running in dev mode?): ${execPath}`
+      }
+    };
+  }
+
+  const appName = path.basename(appBundlePath);
+  if (!input.bypassDevCheck && /^Electron(\b|\.app$)/u.test(appName)) {
+    return {
+      ok: false,
+      refusal: {
+        reason: "not-packaged",
+        detail: `Running inside Electron.app — auto-install is only for packaged Marshal builds`
+      }
+    };
+  }
+
+  if (appBundlePath.startsWith("/Volumes/")) {
+    return {
+      ok: false,
+      refusal: {
+        reason: "read-only-volume",
+        detail: `Running from a DMG / external mount: ${appBundlePath}. Drag Marshal into /Applications first, then check for updates again.`
+      }
+    };
+  }
+
+  const installDir = path.dirname(appBundlePath);
+  if (!installDir || installDir === "/" || installDir === ".") {
+    return {
+      ok: false,
+      refusal: {
+        reason: "unknown-layout",
+        detail: `Cannot resolve install dir from: ${appBundlePath}`
+      }
+    };
+  }
+
+  return {
+    ok: true,
+    plan: {
+      currentAppPath: appBundlePath,
+      installDir,
+      appName
+    }
+  };
+}
+
+/**
+ * Walk up `execPath` to the nearest `*.app` ancestor. Returns `null` when there
+ * is no `.app` in the chain (dev mode, plain `node`-driven scripts, etc.).
+ *
+ * Exported for tests so we can pin the traversal behaviour without going
+ * through the full `planSwap`.
+ */
+export function findAppBundleAncestor(execPath: string): string | null {
+  const segments = execPath.split(path.sep);
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    if (segments[i].toLowerCase().endsWith(".app")) {
+      return segments.slice(0, i + 1).join(path.sep);
+    }
+  }
+  return null;
+}

--- a/desktop/updater/update-checker.ts
+++ b/desktop/updater/update-checker.ts
@@ -1,16 +1,30 @@
 // desktop/updater/update-checker.ts
 //
-// Lightweight "is there a newer release on GitHub?" checker. Lives outside
-// the electron-updater (Squirrel.Mac) ecosystem on purpose — that path needs
-// signed + notarized .app bundles, which we don't have yet (see #78). This
-// service just polls the GitHub Releases API, compares semver tags, and
-// hands the caller a URL to open in the browser. The user installs the new
-// DMG manually.
+// "Is there a newer release on GitHub?" checker. Pulls the latest release via
+// the GitHub Releases API, compares semver tags, and — when the release carries
+// a `latest-mac.yml` metadata asset (which electron-builder publishes
+// automatically) — surfaces the ZIP asset URL plus SHA-512 so the in-app
+// installer (`./update-installer.ts`) can download and atomically swap the
+// bundle without bouncing the user to a browser.
 //
-// When code signing lands, this module stays as the user-facing "Check for
-// updates…" surface and electron-updater takes over the background install.
+// We stay outside the electron-updater (Squirrel.Mac) ecosystem on purpose —
+// that path needs a Developer ID-signed and notarized bundle, which we don't
+// have yet (see #78). When notarization lands, this module remains the
+// user-facing "Check for updates…" surface and electron-updater takes over the
+// install step.
 
 const RELEASES_API = "https://api.github.com/repos/reznichenkoandrey/marshal/releases/latest";
+
+export interface InstallableAsset {
+  /** Direct URL to the ZIP asset on github.com. */
+  zipUrl: string;
+  /** Base64-encoded SHA-512 of the ZIP — same encoding electron-builder uses. */
+  sha512: string;
+  /** Size in bytes, used for the download progress bar. */
+  size: number;
+  /** Semver of the release this asset is from. */
+  version: string;
+}
 
 export interface UpdateCheckResult {
   /** True if `latestVersion` is strictly greater than `currentVersion`. */
@@ -25,6 +39,12 @@ export interface UpdateCheckResult {
   downloadUrl: string | null;
   /** First ~600 chars of the release body — enough for a notification. */
   releaseNotes: string;
+  /**
+   * Set when the release carries a `latest-mac.yml` describing a ZIP asset.
+   * `null` means we can only point the user at the release page — the in-app
+   * installer refuses to run without verifiable SHA-512 metadata.
+   */
+  installable: InstallableAsset | null;
 }
 
 export interface UpdateCheckFailure {
@@ -59,6 +79,9 @@ export class UpdateChecker {
   // answer when the API returns "not modified".
   private cachedEtag: string | null = null;
   private cachedBody: GithubRelease | null = null;
+  // Parsed latest-mac.yml from the most recent successful fetch — cached
+  // alongside the API body so a 304 still gives us a complete outcome.
+  private cachedInstallable: InstallableAsset | null = null;
 
   constructor(init: UpdateCheckerInit) {
     this.currentVersion = stripLeadingV(init.currentVersion);
@@ -81,7 +104,7 @@ export class UpdateChecker {
     }
 
     if (response.status === 304 && this.cachedBody) {
-      return this.outcomeFromRelease(this.cachedBody);
+      return this.outcomeFromCachedRelease(this.cachedBody, this.cachedInstallable);
     }
 
     if (response.status === 404) {
@@ -94,7 +117,8 @@ export class UpdateChecker {
         latestVersion: this.currentVersion,
         releaseUrl: "",
         downloadUrl: null,
-        releaseNotes: ""
+        releaseNotes: "",
+        installable: null
       };
     }
 
@@ -117,10 +141,19 @@ export class UpdateChecker {
     if (etag) this.cachedEtag = etag;
     this.cachedBody = release;
 
-    return this.outcomeFromRelease(release);
+    // Try to upgrade the outcome with installable metadata. A failure here is
+    // not fatal — we still return a valid outcome, just without the ability to
+    // self-install.
+    const installable = await this.fetchInstallable(release).catch(() => null);
+    this.cachedInstallable = installable;
+
+    return this.outcomeFromCachedRelease(release, installable);
   }
 
-  private outcomeFromRelease(release: GithubRelease): UpdateCheckOutcome {
+  private outcomeFromCachedRelease(
+    release: GithubRelease,
+    installable: InstallableAsset | null
+  ): UpdateCheckOutcome {
     if (release.draft) {
       // Draft releases shouldn't ever satisfy a "check for updates" — they
       // are work in progress on the maintainer side.
@@ -130,7 +163,8 @@ export class UpdateChecker {
         latestVersion: this.currentVersion,
         releaseUrl: release.html_url,
         downloadUrl: null,
-        releaseNotes: ""
+        releaseNotes: "",
+        installable: null
       };
     }
     const latestVersion = stripLeadingV(release.tag_name);
@@ -141,7 +175,29 @@ export class UpdateChecker {
       latestVersion,
       releaseUrl: release.html_url,
       downloadUrl: downloadAsset?.browser_download_url ?? null,
-      releaseNotes: (release.body ?? "").slice(0, 600)
+      releaseNotes: (release.body ?? "").slice(0, 600),
+      installable
+    };
+  }
+
+  private async fetchInstallable(release: GithubRelease): Promise<InstallableAsset | null> {
+    const ymlAsset = release.assets.find((a) => a.name === "latest-mac.yml");
+    const zipAsset = release.assets.find((a) => a.name.toLowerCase().endsWith(".zip"));
+    if (!ymlAsset || !zipAsset) return null;
+
+    const res = await this.fetchImpl(ymlAsset.browser_download_url, {
+      headers: { "User-Agent": "Marshal-Updater" }
+    });
+    if (!res.ok) return null;
+    const yml = await res.text();
+    const parsed = parseLatestMacYml(yml);
+    if (!parsed) return null;
+
+    return {
+      zipUrl: zipAsset.browser_download_url,
+      sha512: parsed.sha512,
+      size: parsed.size,
+      version: stripLeadingV(release.tag_name)
     };
   }
 }
@@ -170,4 +226,73 @@ function parseTriple(version: string): [number, number, number] | null {
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)/u);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Hand-rolled parser for the slice of `latest-mac.yml` we care about. The file
+ * is generated by electron-builder and follows a fixed shape, so we extract
+ * the ZIP entry from the `files:` list without taking a YAML dependency.
+ *
+ * Shape:
+ *   version: 0.1.4
+ *   files:
+ *     - url: Marshal-0.1.4-arm64.zip
+ *       sha512: <base64>
+ *       size: 580374993
+ *     - url: Marshal-0.1.4-arm64.dmg
+ *       sha512: <base64>
+ *       size: ...
+ *   path: Marshal-0.1.4-arm64.zip
+ *   sha512: <base64 of the path file>
+ *
+ * Returns the ZIP entry's sha512+size, or null if the file is malformed.
+ */
+export function parseLatestMacYml(text: string): { sha512: string; size: number } | null {
+  const lines = text.split(/\r?\n/u);
+  let inFiles = false;
+  let current: { url?: string; sha512?: string; size?: number } | null = null;
+  const entries: Array<{ url: string; sha512: string; size: number }> = [];
+
+  const commit = () => {
+    if (current && current.url && current.sha512 && typeof current.size === "number") {
+      entries.push({ url: current.url, sha512: current.sha512, size: current.size });
+    }
+    current = null;
+  };
+
+  for (const rawLine of lines) {
+    if (/^files\s*:\s*$/u.test(rawLine)) {
+      inFiles = true;
+      continue;
+    }
+    if (!inFiles) continue;
+    // A top-level key (no leading whitespace) closes the files block.
+    if (/^[^\s-]/u.test(rawLine)) {
+      commit();
+      inFiles = false;
+      continue;
+    }
+    const dashMatch = rawLine.match(/^\s*-\s*url\s*:\s*(.+?)\s*$/u);
+    if (dashMatch) {
+      commit();
+      current = { url: dashMatch[1] };
+      continue;
+    }
+    if (!current) continue;
+    const shaMatch = rawLine.match(/^\s+sha512\s*:\s*(.+?)\s*$/u);
+    if (shaMatch) {
+      current.sha512 = shaMatch[1];
+      continue;
+    }
+    const sizeMatch = rawLine.match(/^\s+size\s*:\s*(\d+)\s*$/u);
+    if (sizeMatch) {
+      current.size = Number(sizeMatch[1]);
+      continue;
+    }
+  }
+  commit();
+
+  const zip = entries.find((e) => e.url.toLowerCase().endsWith(".zip"));
+  if (!zip) return null;
+  return { sha512: zip.sha512, size: zip.size };
 }

--- a/desktop/updater/update-installer.ts
+++ b/desktop/updater/update-installer.ts
@@ -1,0 +1,411 @@
+// desktop/updater/update-installer.ts
+//
+// In-process implementation of the "Download & install" button. Given an
+// `InstallableAsset` from the checker, we:
+//
+//   1. Stream the ZIP into a temp file under `os.tmpdir()`, hashing as we go.
+//   2. Verify the SHA-512 against `latest-mac.yml`. Mismatch → abort, the temp
+//      file is deleted, the bundle is never touched.
+//   3. Extract with `/usr/bin/ditto` (preserves code-sign / Info.plist /
+//      symlink attributes that a stock unzip would mangle).
+//   4. Write a small bash script to a fresh temp dir that:
+//        a. Waits for our PID to exit.
+//        b. Strips com.apple.quarantine from the new bundle.
+//        c. Two-phase swap with rollback on failure.
+//        d. Re-opens Marshal.
+//   5. Spawn the script detached, then call `app.quit()` so the user sees
+//      Marshal disappear and pop back up on the new version.
+//
+// The "compute SHA + write script + spawn" plumbing is exposed as small public
+// methods so tests can drive each stage without running ditto for real.
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { InstallableAsset } from "./update-checker.ts";
+import type { SwapPlan } from "./swap-planner.ts";
+
+export type InstallPhase =
+  | "starting"
+  | "downloading"
+  | "verifying"
+  | "extracting"
+  | "staging"
+  | "relaunching"
+  | "done"
+  | "error";
+
+export interface InstallProgress {
+  phase: InstallPhase;
+  /** 0..1 within the current phase (NaN if not meaningful). */
+  ratio: number;
+  /** Optional human-readable detail. */
+  message?: string;
+  /** Bytes downloaded so far — present for `downloading`. */
+  bytesDownloaded?: number;
+  /** Total bytes of the asset — present for `downloading`. */
+  bytesTotal?: number;
+}
+
+export interface InstallerInit {
+  /** Where to keep the downloaded zip + extracted bundle. Defaults to os.tmpdir(). */
+  scratchRoot?: string;
+  /** Inject fetch / spawn for tests. */
+  fetchImpl?: typeof fetch;
+  spawnImpl?: typeof spawn;
+  /** PID the post-quit script waits on. Defaults to `process.pid`. */
+  parentPid?: number;
+}
+
+export type ProgressListener = (p: InstallProgress) => void;
+
+export class UpdateInstaller {
+  private readonly scratchRoot: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly spawnImpl: typeof spawn;
+  private readonly parentPid: number;
+  private readonly listeners = new Set<ProgressListener>();
+
+  constructor(init: InstallerInit = {}) {
+    this.scratchRoot = init.scratchRoot ?? path.join(os.tmpdir(), "marshal-update");
+    this.fetchImpl = init.fetchImpl ?? globalThis.fetch;
+    this.spawnImpl = init.spawnImpl ?? spawn;
+    this.parentPid = init.parentPid ?? process.pid;
+  }
+
+  onProgress(listener: ProgressListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * Full pipeline: download → verify → extract → stage swap script. Returns the
+   * paths the caller needs in order to spawn the script and quit.
+   *
+   * Throws on any failure — the caller is responsible for surfacing the error
+   * to the UI. We never partially mutate the installed bundle: the swap is
+   * only performed by the detached script after `commit()` is called.
+   */
+  async prepare(asset: InstallableAsset, plan: SwapPlan): Promise<PreparedInstall> {
+    this.emit({ phase: "starting", ratio: 0 });
+    const stagingDir = await this.makeStagingDir(asset.version);
+    const zipPath = path.join(stagingDir, "marshal.zip");
+
+    try {
+      await this.download(asset, zipPath);
+      await this.verify(zipPath, asset.sha512);
+      const newAppPath = await this.extract(zipPath, stagingDir, plan.appName);
+      const scriptPath = await this.writeSwapScript(stagingDir, plan, newAppPath);
+      this.emit({ phase: "staging", ratio: 1 });
+      return { stagingDir, zipPath, newAppPath, scriptPath, plan };
+    } catch (err) {
+      this.emit({
+        phase: "error",
+        ratio: NaN,
+        message: err instanceof Error ? err.message : String(err)
+      });
+      await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+      throw err;
+    }
+  }
+
+  /**
+   * Spawn the detached post-quit script. After this returns, the caller MUST
+   * `app.quit()` immediately — the script will wait up to ~30 s for our pid to
+   * exit before swapping the bundle.
+   */
+  commit(prepared: PreparedInstall): void {
+    this.emit({ phase: "relaunching", ratio: 1 });
+    const logPath = path.join(prepared.stagingDir, "swap.log");
+    const child = this.spawnImpl(
+      "/bin/bash",
+      [
+        prepared.scriptPath,
+        String(this.parentPid),
+        prepared.newAppPath,
+        prepared.plan.installDir,
+        prepared.plan.appName,
+        logPath
+      ],
+      {
+        detached: true,
+        stdio: "ignore"
+      }
+    );
+    child.unref();
+  }
+
+  // ── individual stages ──
+
+  private async download(asset: InstallableAsset, zipPath: string): Promise<void> {
+    this.emit({ phase: "downloading", ratio: 0, bytesDownloaded: 0, bytesTotal: asset.size });
+    const res = await this.fetchImpl(asset.zipUrl, {
+      headers: { "User-Agent": "Marshal-Updater" }
+    });
+    if (!res.ok || !res.body) {
+      throw new Error(`Download failed: HTTP ${res.status}`);
+    }
+    const total =
+      Number(res.headers.get("content-length") ?? "") || asset.size;
+    let received = 0;
+
+    const fileStream = createWriteStream(zipPath);
+    const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+
+    try {
+      // Manual chunk loop so we can emit progress + write to disk at the same
+      // time. `Response.body.pipeTo(WritableStream)` would be cleaner but loses
+      // us the chunk-by-chunk hook.
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        received += value.byteLength;
+        await new Promise<void>((resolve, reject) => {
+          fileStream.write(value, (err) => (err ? reject(err) : resolve()));
+        });
+        if (total > 0) {
+          this.emit({
+            phase: "downloading",
+            ratio: Math.min(1, received / total),
+            bytesDownloaded: received,
+            bytesTotal: total
+          });
+        }
+      }
+    } finally {
+      await new Promise<void>((resolve) => fileStream.end(() => resolve()));
+    }
+  }
+
+  private async verify(zipPath: string, expectedSha512: string): Promise<void> {
+    this.emit({ phase: "verifying", ratio: 0 });
+    const actual = await sha512Base64(zipPath);
+    if (actual !== expectedSha512) {
+      throw new Error(
+        `SHA-512 mismatch — refusing to install. expected=${truncate(expectedSha512, 20)} actual=${truncate(actual, 20)}`
+      );
+    }
+    this.emit({ phase: "verifying", ratio: 1 });
+  }
+
+  private async extract(
+    zipPath: string,
+    stagingDir: string,
+    appName: string
+  ): Promise<string> {
+    this.emit({ phase: "extracting", ratio: 0 });
+    const extractDir = path.join(stagingDir, "extracted");
+    await fs.mkdir(extractDir, { recursive: true });
+
+    // `ditto -x -k <zip> <dest>` is the macOS-native way to unzip while
+    // preserving HFS+ metadata, extended attributes, and symlinks. The stock
+    // /usr/bin/unzip drops those, which corrupts code-signed bundles.
+    await runProcess(
+      this.spawnImpl,
+      "/usr/bin/ditto",
+      ["-x", "-k", zipPath, extractDir]
+    );
+
+    // electron-builder's ZIPs put the bundle at the top level. Locate it
+    // explicitly so we don't depend on the exact filename casing.
+    const entries = await fs.readdir(extractDir);
+    const bundleName = entries.find((e) => e.toLowerCase().endsWith(".app"));
+    if (!bundleName) {
+      throw new Error(`Extracted archive does not contain a .app bundle in ${extractDir}`);
+    }
+    // If the running install is `Marshal.app` but the bundle inside the zip is
+    // `Marshal beta.app` etc., the post-quit script would try to mv it onto the
+    // wrong name. Rename here, in our own staging dir, so the script can stay
+    // simple.
+    const finalPath = path.join(extractDir, appName);
+    if (bundleName !== appName) {
+      await fs.rename(path.join(extractDir, bundleName), finalPath);
+    }
+
+    this.emit({ phase: "extracting", ratio: 1 });
+    return finalPath;
+  }
+
+  private async writeSwapScript(
+    stagingDir: string,
+    plan: SwapPlan,
+    newAppPath: string
+  ): Promise<string> {
+    const scriptPath = path.join(stagingDir, "post-quit-installer.sh");
+    await fs.writeFile(scriptPath, buildSwapScript(), "utf8");
+    await fs.chmod(scriptPath, 0o755);
+    // Touch a sanity-check log line so we know the file is real.
+    void newAppPath;
+    void plan;
+    return scriptPath;
+  }
+
+  private async makeStagingDir(version: string): Promise<string> {
+    await fs.mkdir(this.scratchRoot, { recursive: true });
+    const dir = await fs.mkdtemp(path.join(this.scratchRoot, `v${version}-`));
+    return dir;
+  }
+
+  private emit(p: InstallProgress): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(p);
+      } catch (err) {
+        // A misbehaving listener must not break the install pipeline.
+        console.warn("[update-installer] progress listener threw:", err);
+      }
+    }
+  }
+}
+
+export interface PreparedInstall {
+  stagingDir: string;
+  zipPath: string;
+  newAppPath: string;
+  scriptPath: string;
+  plan: SwapPlan;
+}
+
+/**
+ * Compute the base64 SHA-512 of a file, streamed so we never load the whole
+ * ZIP into memory.
+ */
+export async function sha512Base64(filePath: string): Promise<string> {
+  const handle = await fs.open(filePath, "r");
+  try {
+    const hash = createHash("sha512");
+    const stream = handle.createReadStream({ highWaterMark: 1024 * 1024 });
+    await new Promise<void>((resolve, reject) => {
+      stream.on("data", (chunk: Buffer | string) => {
+        hash.update(chunk);
+      });
+      stream.on("end", () => resolve());
+      stream.on("error", reject);
+    });
+    return hash.digest("base64");
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Builds the bash payload that performs the post-quit swap. Generated at
+ * runtime so we don't have to ship a separate `.sh` asset through the
+ * electron-builder asar.
+ */
+export function buildSwapScript(): string {
+  // The script is small and self-contained on purpose: it runs after Marshal
+  // has quit, so it cannot lean on any Node/Electron helpers. Arguments:
+  //   $1 PARENT_PID
+  //   $2 STAGING_APP   (e.g. /tmp/marshal-update/v0.1.5-XXXX/extracted/Marshal.app)
+  //   $3 INSTALL_DIR   (e.g. /Applications)
+  //   $4 APP_NAME      (e.g. Marshal.app)
+  //   $5 LOG_PATH      (sibling of STAGING_APP)
+  return `#!/bin/bash
+# Marshal post-quit installer — generated by desktop/updater/update-installer.ts
+set -u
+
+PARENT_PID="\${1:-}"
+STAGING_APP="\${2:-}"
+INSTALL_DIR="\${3:-}"
+APP_NAME="\${4:-}"
+LOG="\${5:-/tmp/marshal-installer.log}"
+
+exec >>"$LOG" 2>&1
+echo
+echo "[post-quit-installer] start $(date)"
+echo "  parent pid : $PARENT_PID"
+echo "  staging app: $STAGING_APP"
+echo "  install dir: $INSTALL_DIR"
+echo "  app name   : $APP_NAME"
+
+INSTALL_APP="$INSTALL_DIR/$APP_NAME"
+
+if [ ! -d "$STAGING_APP" ]; then
+  echo "ERROR: staging app missing — aborting"
+  exit 1
+fi
+
+if [ ! -w "$INSTALL_DIR" ]; then
+  echo "ERROR: install dir not writable — aborting"
+  exit 2
+fi
+
+# Wait for Marshal main to actually quit (max ~30s).
+i=0
+while [ "$i" -lt 300 ] && kill -0 "$PARENT_PID" 2>/dev/null; do
+  sleep 0.1
+  i=$((i+1))
+done
+
+if kill -0 "$PARENT_PID" 2>/dev/null; then
+  echo "WARN: parent still alive after 30s — forcing kill"
+  kill -KILL "$PARENT_PID" 2>/dev/null || true
+  sleep 1
+fi
+
+# Strip quarantine so macOS does not re-prompt on next launch.
+/usr/bin/xattr -dr com.apple.quarantine "$STAGING_APP" 2>/dev/null || true
+
+# Two-phase swap with rollback if mv-in fails.
+BACKUP=""
+if [ -d "$INSTALL_APP" ]; then
+  BACKUP="$INSTALL_APP.old-$$"
+  if ! mv "$INSTALL_APP" "$BACKUP"; then
+    echo "ERROR: could not move old bundle aside"
+    exit 3
+  fi
+fi
+
+if ! mv "$STAGING_APP" "$INSTALL_APP"; then
+  echo "ERROR: could not move new bundle into place — rolling back"
+  if [ -n "$BACKUP" ] && [ -d "$BACKUP" ]; then
+    mv "$BACKUP" "$INSTALL_APP" || true
+  fi
+  exit 4
+fi
+
+if [ -n "$BACKUP" ]; then
+  rm -rf "$BACKUP" 2>/dev/null || true
+fi
+
+# Re-launch the freshly installed bundle.
+/usr/bin/open "$INSTALL_APP"
+
+echo "[post-quit-installer] done $(date)"
+exit 0
+`;
+}
+
+// ── helpers ──
+
+function runProcess(
+  spawnImpl: typeof spawn,
+  cmd: string,
+  args: string[]
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawnImpl(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${cmd} exited with code ${code}: ${stderr.trim()}`));
+      }
+    });
+  });
+}
+
+function truncate(value: string, n: number): string {
+  return value.length <= n ? value : `${value.slice(0, n)}…`;
+}

--- a/tests/swap-planner.test.ts
+++ b/tests/swap-planner.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { findAppBundleAncestor, planSwap } from "../desktop/updater/swap-planner.ts";
+
+describe("findAppBundleAncestor", () => {
+  it("finds the .app bundle in a normal install layout", () => {
+    expect(findAppBundleAncestor("/Applications/Marshal.app/Contents/MacOS/Marshal")).toBe(
+      "/Applications/Marshal.app"
+    );
+  });
+
+  it("returns the deepest .app when nested", () => {
+    expect(
+      findAppBundleAncestor("/Volumes/Marshal/Marshal.app/Contents/MacOS/Marshal")
+    ).toBe("/Volumes/Marshal/Marshal.app");
+  });
+
+  it("returns null for a plain node script", () => {
+    expect(findAppBundleAncestor("/usr/local/bin/node")).toBeNull();
+  });
+});
+
+describe("planSwap", () => {
+  it("approves a normal /Applications install", () => {
+    const decision = planSwap({
+      execPath: "/Applications/Marshal.app/Contents/MacOS/Marshal"
+    });
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) return;
+    expect(decision.plan).toEqual({
+      currentAppPath: "/Applications/Marshal.app",
+      installDir: "/Applications",
+      appName: "Marshal.app"
+    });
+  });
+
+  it("approves an install in a user directory", () => {
+    const decision = planSwap({
+      execPath: "/Users/alex/Downloads/Marshal.app/Contents/MacOS/Marshal"
+    });
+    expect(decision.ok).toBe(true);
+    if (!decision.ok) return;
+    expect(decision.plan.installDir).toBe("/Users/alex/Downloads");
+  });
+
+  it("refuses dev-mode Electron (Electron.app ancestor)", () => {
+    const decision = planSwap({
+      execPath:
+        "/Users/me/htdocs/marshal/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron"
+    });
+    expect(decision.ok).toBe(false);
+    if (decision.ok) return;
+    expect(decision.refusal.reason).toBe("not-packaged");
+  });
+
+  it("refuses a DMG-mounted bundle on /Volumes/", () => {
+    const decision = planSwap({
+      execPath: "/Volumes/Marshal 0.1.4/Marshal.app/Contents/MacOS/Marshal"
+    });
+    expect(decision.ok).toBe(false);
+    if (decision.ok) return;
+    expect(decision.refusal.reason).toBe("read-only-volume");
+  });
+
+  it("refuses when execPath is not inside a .app at all", () => {
+    const decision = planSwap({ execPath: "/usr/local/bin/some-binary" });
+    expect(decision.ok).toBe(false);
+    if (decision.ok) return;
+    expect(decision.refusal.reason).toBe("not-packaged");
+  });
+
+  it("allows bypassing the Electron check for test fixtures", () => {
+    const decision = planSwap({
+      execPath: "/Users/me/Electron.app/Contents/MacOS/Electron",
+      bypassDevCheck: true
+    });
+    expect(decision.ok).toBe(true);
+  });
+});

--- a/tests/update-checker.test.ts
+++ b/tests/update-checker.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { UpdateChecker, isNewer, stripLeadingV } from "../desktop/updater/update-checker.ts";
+import {
+  UpdateChecker,
+  isNewer,
+  parseLatestMacYml,
+  stripLeadingV
+} from "../desktop/updater/update-checker.ts";
 
 describe("stripLeadingV", () => {
   it("removes a leading v", () => {
@@ -216,5 +221,152 @@ describe("UpdateChecker.check", () => {
     expect(r.available).toBe(true);
     if (!r.available) return;
     expect(r.downloadUrl).toBeNull();
+  });
+
+  it("populates `installable` when latest-mac.yml is present", async () => {
+    const releaseBody = {
+      tag_name: "v0.2.0",
+      html_url: "https://example/release",
+      name: "0.2.0",
+      body: "notes",
+      draft: false,
+      prerelease: false,
+      assets: [
+        {
+          name: "Marshal-0.2.0-arm64.zip",
+          browser_download_url: "https://example/Marshal-0.2.0-arm64.zip"
+        },
+        {
+          name: "Marshal-0.2.0-arm64.dmg",
+          browser_download_url: "https://example/Marshal-0.2.0-arm64.dmg"
+        },
+        {
+          name: "latest-mac.yml",
+          browser_download_url: "https://example/latest-mac.yml"
+        }
+      ]
+    };
+    const yml = `version: 0.2.0
+files:
+  - url: Marshal-0.2.0-arm64.zip
+    sha512: ZIPSHA==
+    size: 12345
+  - url: Marshal-0.2.0-arm64.dmg
+    sha512: DMGSHA==
+    size: 67890
+path: Marshal-0.2.0-arm64.zip
+sha512: ZIPSHA==
+releaseDate: '2026-01-01T00:00:00.000Z'
+`;
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("latest-mac.yml")) {
+        return new Response(yml, { status: 200 });
+      }
+      return new Response(JSON.stringify(releaseBody), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const checker = new UpdateChecker({ currentVersion: "0.1.0", fetchImpl });
+    const r = await checker.check();
+    expect(r.available).toBe(true);
+    if (!r.available) return;
+    expect(r.installable).toEqual({
+      zipUrl: "https://example/Marshal-0.2.0-arm64.zip",
+      sha512: "ZIPSHA==",
+      size: 12345,
+      version: "0.2.0"
+    });
+  });
+
+  it("leaves installable=null when the release has no latest-mac.yml", async () => {
+    const fetchImpl = buildFetch({
+      body: {
+        tag_name: "v0.2.0",
+        html_url: "https://example/release",
+        name: "0.2.0",
+        body: "",
+        draft: false,
+        prerelease: false,
+        assets: [
+          {
+            name: "Marshal-0.2.0-arm64.zip",
+            browser_download_url: "https://example/zip"
+          }
+        ]
+      }
+    });
+    const checker = new UpdateChecker({ currentVersion: "0.1.0", fetchImpl });
+    const r = await checker.check();
+    expect(r.available).toBe(true);
+    if (!r.available) return;
+    expect(r.installable).toBeNull();
+  });
+
+  it("falls back gracefully when the yml fetch fails", async () => {
+    const releaseBody = {
+      tag_name: "v0.2.0",
+      html_url: "https://example/release",
+      name: "0.2.0",
+      body: "",
+      draft: false,
+      prerelease: false,
+      assets: [
+        {
+          name: "Marshal-0.2.0-arm64.zip",
+          browser_download_url: "https://example/zip"
+        },
+        {
+          name: "latest-mac.yml",
+          browser_download_url: "https://example/latest-mac.yml"
+        }
+      ]
+    };
+    const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("latest-mac.yml")) {
+        return new Response("", { status: 500 });
+      }
+      return new Response(JSON.stringify(releaseBody), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const checker = new UpdateChecker({ currentVersion: "0.1.0", fetchImpl });
+    const r = await checker.check();
+    expect(r.available).toBe(true);
+    if (!r.available) return;
+    expect(r.installable).toBeNull();
+  });
+});
+
+describe("parseLatestMacYml", () => {
+  it("extracts the zip entry from a real-shaped yml", () => {
+    const yml = `version: 0.1.4
+files:
+  - url: Marshal-0.1.4-arm64.zip
+    sha512: AAA==
+    size: 580374993
+  - url: Marshal-0.1.4-arm64.dmg
+    sha512: BBB==
+    size: 586373121
+path: Marshal-0.1.4-arm64.zip
+sha512: AAA==
+releaseDate: '2026-05-19T19:51:58.145Z'
+`;
+    expect(parseLatestMacYml(yml)).toEqual({ sha512: "AAA==", size: 580374993 });
+  });
+
+  it("returns null when no zip entry exists", () => {
+    const yml = `version: 0.1.4
+files:
+  - url: Marshal-0.1.4-arm64.dmg
+    sha512: BBB==
+    size: 1
+path: Marshal-0.1.4-arm64.dmg
+`;
+    expect(parseLatestMacYml(yml)).toBeNull();
+  });
+
+  it("returns null on malformed input", () => {
+    expect(parseLatestMacYml("not yaml at all")).toBeNull();
+    expect(parseLatestMacYml("")).toBeNull();
   });
 });

--- a/tests/update-installer.test.ts
+++ b/tests/update-installer.test.ts
@@ -1,0 +1,202 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  UpdateInstaller,
+  buildSwapScript,
+  sha512Base64
+} from "../desktop/updater/update-installer.ts";
+
+describe("sha512Base64", () => {
+  let tmp: string;
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), "marshal-sha-test-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it("matches Node's reference digest for a known file", async () => {
+    const filePath = path.join(tmp, "data.bin");
+    const payload = Buffer.from("marshal-updater-test-payload");
+    await fs.writeFile(filePath, payload);
+
+    const expected = createHash("sha512").update(payload).digest("base64");
+    const actual = await sha512Base64(filePath);
+
+    expect(actual).toBe(expected);
+  });
+
+  it("handles empty files", async () => {
+    const filePath = path.join(tmp, "empty.bin");
+    await fs.writeFile(filePath, "");
+    const expected = createHash("sha512").update("").digest("base64");
+    const actual = await sha512Base64(filePath);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe("buildSwapScript", () => {
+  it("emits a bash script with shebang and uses all five positional args", () => {
+    const script = buildSwapScript();
+    expect(script.startsWith("#!/bin/bash")).toBe(true);
+    // All five expected positional parameters must appear at least once.
+    expect(script).toMatch(/PARENT_PID="\$\{1:-\}"/);
+    expect(script).toMatch(/STAGING_APP="\$\{2:-\}"/);
+    expect(script).toMatch(/INSTALL_DIR="\$\{3:-\}"/);
+    expect(script).toMatch(/APP_NAME="\$\{4:-\}"/);
+    expect(script).toMatch(/LOG="\$\{5:-/);
+  });
+
+  it("two-phase swap pattern: backup, install new, cleanup on success", () => {
+    const script = buildSwapScript();
+    // The order of mv operations is the safety contract — verify it's there.
+    expect(script.indexOf('mv "$INSTALL_APP" "$BACKUP"')).toBeGreaterThan(0);
+    expect(script.indexOf('mv "$STAGING_APP" "$INSTALL_APP"')).toBeGreaterThan(
+      script.indexOf('mv "$INSTALL_APP" "$BACKUP"')
+    );
+    expect(script).toContain('rm -rf "$BACKUP"');
+  });
+
+  it("rolls back the backup if mv-in fails", () => {
+    const script = buildSwapScript();
+    expect(script).toMatch(/rolling back/);
+    expect(script).toMatch(/mv "\$BACKUP" "\$INSTALL_APP"/);
+  });
+
+  it("opens the bundle at the end", () => {
+    const script = buildSwapScript();
+    expect(script).toContain('/usr/bin/open "$INSTALL_APP"');
+  });
+
+  it("strips com.apple.quarantine before swapping", () => {
+    const script = buildSwapScript();
+    expect(script).toContain("xattr -dr com.apple.quarantine");
+  });
+});
+
+describe("UpdateInstaller.prepare — happy path", () => {
+  // A self-contained pipeline test that drives the installer with an in-memory
+  // ZIP payload and stubbed ditto-replacement to validate the end-to-end flow
+  // without touching `/usr/bin/ditto`.
+  let scratch: string;
+
+  beforeEach(async () => {
+    scratch = await fs.mkdtemp(path.join(os.tmpdir(), "marshal-installer-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(scratch, { recursive: true, force: true });
+  });
+
+  it("downloads, verifies sha, stages a script and produces a plan", async () => {
+    const zipPayload = Buffer.from("not-a-real-zip-but-shaped-the-same");
+    const sha = createHash("sha512").update(zipPayload).digest("base64");
+
+    // Stub fetch to return the payload.
+    const fetchImpl = (async () =>
+      new Response(zipPayload, {
+        status: 200,
+        headers: { "content-length": String(zipPayload.length) }
+      })) as unknown as typeof fetch;
+
+    // Stub spawn so `ditto` is replaced by a no-op that creates the .app dir.
+    const fakeSpawn = ((cmd: string, args: string[]) => {
+      const child = {
+        stdout: null,
+        stderr: { on: () => undefined },
+        on: (event: string, cb: (code: number) => void) => {
+          if (event === "close") {
+            if (cmd === "/usr/bin/ditto") {
+              // ditto -x -k <zip> <dest>
+              const dest = args[args.length - 1];
+              void (async () => {
+                await fs.mkdir(path.join(dest, "Marshal.app"), { recursive: true });
+                cb(0);
+              })();
+            } else {
+              cb(0);
+            }
+          }
+          return child;
+        },
+        unref: () => undefined
+      };
+      return child;
+    }) as unknown as typeof import("node:child_process").spawn;
+
+    const installer = new UpdateInstaller({
+      scratchRoot: scratch,
+      fetchImpl,
+      spawnImpl: fakeSpawn,
+      parentPid: 99999
+    });
+
+    const phases: string[] = [];
+    installer.onProgress((p) => phases.push(p.phase));
+
+    const prepared = await installer.prepare(
+      { zipUrl: "https://example/zip", sha512: sha, size: zipPayload.length, version: "0.1.5" },
+      {
+        currentAppPath: "/Applications/Marshal.app",
+        installDir: "/Applications",
+        appName: "Marshal.app"
+      }
+    );
+
+    expect(prepared.plan.appName).toBe("Marshal.app");
+    expect(await fs.stat(prepared.newAppPath).then((s) => s.isDirectory())).toBe(true);
+    expect(await fs.readFile(prepared.scriptPath, "utf8")).toContain("post-quit-installer");
+    expect(phases).toContain("downloading");
+    expect(phases).toContain("verifying");
+    expect(phases).toContain("extracting");
+    expect(phases.at(-1)).toBe("staging");
+  });
+
+  it("aborts and emits an error phase when the SHA does not match", async () => {
+    const zipPayload = Buffer.from("payload");
+    const fetchImpl = (async () =>
+      new Response(zipPayload, {
+        status: 200,
+        headers: { "content-length": String(zipPayload.length) }
+      })) as unknown as typeof fetch;
+
+    // ditto is never reached but we still provide a stub.
+    const fakeSpawn = ((..._args: unknown[]) => ({
+      stdout: null,
+      stderr: { on: () => undefined },
+      on: (event: string, cb: (code: number) => void) => {
+        if (event === "close") cb(0);
+        return { unref: () => undefined };
+      },
+      unref: () => undefined
+    })) as unknown as typeof import("node:child_process").spawn;
+
+    const installer = new UpdateInstaller({
+      scratchRoot: scratch,
+      fetchImpl,
+      spawnImpl: fakeSpawn,
+      parentPid: 99999
+    });
+
+    const phases: string[] = [];
+    installer.onProgress((p) => phases.push(p.phase));
+
+    await expect(
+      installer.prepare(
+        { zipUrl: "https://example/zip", sha512: "wrong-sha", size: zipPayload.length, version: "0.1.5" },
+        {
+          currentAppPath: "/Applications/Marshal.app",
+          installDir: "/Applications",
+          appName: "Marshal.app"
+        }
+      )
+    ).rejects.toThrow(/SHA-512 mismatch/);
+
+    expect(phases.at(-1)).toBe("error");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a custom in-process updater so the "Download & install" button in Settings now downloads the ZIP, verifies SHA-512 against `latest-mac.yml`, and atomically swaps `Marshal.app` + relaunches — no manual DMG dance.
- Stays outside `electron-updater` / Squirrel.Mac because we are self-signed and not yet Apple-notarized (notarization tracked in #78). When notarization lands we can migrate without changing the UI contract.
- New module split: `desktop/updater/update-checker.ts` (extended), `swap-planner.ts` (pure), `update-installer.ts` (download / verify / extract / stage / spawn). Swap script generated at runtime and spawned detached so no extra asset has to ship through asar.

## Why custom and not `electron-updater`

Squirrel.Mac requires a Developer ID-signed and notarized `.app`. Our current bundle is signed with the `Marshal Self-Signed` identity (`TeamIdentifier=not set`, `spctl -a` rejects it). Without notarization Gatekeeper blocks the replaced bundle and Squirrel silently fails. Custom swap works because we never re-trigger Gatekeeper's first-launch check — the user already accepted the bundle on first install.

## How the swap works

1. Re-check via `UpdateChecker` → produces `installable { zipUrl, sha512, size, version }` parsed out of `latest-mac.yml`.
2. `planSwap` refuses dev-mode Electron, `/Volumes/` DMG mounts, and bundles without a writable parent dir; returns `currentAppPath / installDir / appName` otherwise.
3. Stream ZIP into `os.tmpdir()/marshal-update/v<X.Y.Z>-XXXXXX/`, emitting `downloading` progress events per chunk.
4. `sha512Base64` hashes the file on disk and compares against the yml; mismatch → abort, scratch wiped.
5. `/usr/bin/ditto -x -k` extracts (preserves code-sign metadata; `unzip` mangles it).
6. Generate a bash script in the scratch dir (`buildSwapScript`) and spawn it detached. The script:
   - waits up to 30 s for the parent pid to exit,
   - strips `com.apple.quarantine` on the staged bundle,
   - does a two-phase `mv` with rollback if the activation step fails,
   - `open`s the new bundle.
7. Main calls `app.quit()` ~250 ms after spawning so the renderer can paint the "Relaunching…" state.

## UI

- Settings update card now shows **Download & install** as the primary CTA plus an "Open release page" secondary link as a fallback.
- During install: determinate progress bar, phase labels (`Downloading…` → `Verifying signature…` → `Unpacking…` → `Staging install…` → `Relaunching…`), and a `X MB / Y MB` readout while downloading.
- On error: inline error message + Retry button.
- If the release has no `latest-mac.yml` the install button is hidden and the user still gets the original "Open release page" link.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 207 tests passing (24 update-checker, 9 swap-planner, 9 update-installer)
- [ ] Manual smoke on a packaged build: cut a new release, click Download & install on v0.1.4, confirm the running version reports as the new tag after relaunch
- [ ] Manual smoke: refusal path — launch from a DMG-attached volume, confirm the UI shows the read-only-volume refusal instead of silently failing
- [ ] Manual smoke: SHA mismatch path — point the checker at a release whose yml has a doctored hash, confirm the install aborts cleanly and leaves the running bundle intact

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)