### PR TITLE
fix(dictation): spawn from app.asar.unpacked + startup TCC diagnostics

### DIFF
--- a/desktop/capture/scroll-capture.ts
+++ b/desktop/capture/scroll-capture.ts
@@ -19,10 +19,14 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { asarUnpacked } from "../utils/asar-paths.ts";
+
 const currentFilePath = fileURLToPath(import.meta.url);
 const desktopDistDir = path.dirname(currentFilePath);
-const scrollCaptureBin = path.join(desktopDistDir, "scroll-capture");
-const scrollStitchBin = path.join(desktopDistDir, "scroll-stitch");
+// asarUnpacked() — `child_process.spawn` cannot descend into app.asar (#82).
+const desktopDistDirOnDisk = asarUnpacked(desktopDistDir);
+const scrollCaptureBin = path.join(desktopDistDirOnDisk, "scroll-capture");
+const scrollStitchBin = path.join(desktopDistDirOnDisk, "scroll-stitch");
 
 export interface ScrollCaptureOptions {
   /** Capture rectangle in CSS pixels. */

--- a/desktop/capture/video-recorder.ts
+++ b/desktop/capture/video-recorder.ts
@@ -11,11 +11,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { asarUnpacked } from "../utils/asar-paths.ts";
+
 const currentFilePath = fileURLToPath(import.meta.url);
 const desktopDistDir = path.dirname(currentFilePath);
 // video-recorder.ts compiles to dist/desktop/capture/; the Swift binary sits
 // next to it at dist/desktop/capture/screen-recorder (set by postbuild.mjs).
-const BINARY_PATH = path.join(desktopDistDir, "screen-recorder");
+// asarUnpacked() — `child_process.spawn` cannot descend into app.asar (#82).
+const BINARY_PATH = path.join(asarUnpacked(desktopDistDir), "screen-recorder");
 
 export interface VideoArea {
   /** Origin x in display-local CSS pixels (pre-Retina). */

--- a/desktop/dictation/dictation-service.ts
+++ b/desktop/dictation/dictation-service.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from "node:url";
 import { clipboard } from "electron";
 
 import { PushToTalkHotkey } from "./hotkey-manager.ts";
+import { asarUnpacked } from "../utils/asar-paths.ts";
 import {
   createWhisperBackend,
   resolveBackendName,
@@ -33,7 +34,8 @@ const DEFAULT_HOTKEY = "RightCmd";
 const MAX_RECORDING_MS = 60_000;
 const currentFilePath = fileURLToPath(import.meta.url);
 const distDictationDir = path.dirname(currentFilePath);
-const DEFAULT_RECORDER_BIN = path.join(distDictationDir, "audio-recorder");
+// asarUnpacked() — `child_process.spawn` cannot descend into app.asar (#82).
+const DEFAULT_RECORDER_BIN = path.join(asarUnpacked(distDictationDir), "audio-recorder");
 
 function debug(...args: unknown[]): void {
   if (process.env.MARSHAL_DICTATION_DEBUG === "1") {

--- a/desktop/dictation/hotkey-manager.ts
+++ b/desktop/dictation/hotkey-manager.ts
@@ -191,9 +191,43 @@ export class PushToTalkHotkey extends EventEmitter {
 
   start(): void {
     if (this.started) return;
+    console.log(`[hotkey] start() keycode=${this.spec.keycode} meta=${this.spec.meta} ctrl=${this.spec.ctrl} alt=${this.spec.alt} shift=${this.spec.shift}`);
+
+    // Catch-all probes. If uiohook's event loop is alive at all, we'll see
+    // *any* keydown / mousemove line in the log. Silence under these means
+    // the native CGEventTap was created but is not receiving events — almost
+    // always a macOS Sequoia uiohook-napi compatibility issue rather than a
+    // TCC permission gate (which would have failed acquireUiohook()).
+    let firstKey = true;
+    let firstMouse = true;
+    const probeKey = (e: UiohookKeyboardEvent) => {
+      if (firstKey) {
+        console.log(`[hotkey][probe] FIRST keydown received keycode=${e.keycode}`);
+        firstKey = false;
+      }
+    };
+    const probeMouse = () => {
+      if (firstMouse) {
+        console.log(`[hotkey][probe] FIRST mousemove received`);
+        firstMouse = false;
+      }
+    };
+    uIOhook.on("keydown", probeKey);
+    uIOhook.on("mousemove", probeMouse);
+
     uIOhook.on("keydown", this.downHandler);
     uIOhook.on("keyup", this.upHandler);
-    this.hookRelease = acquireUiohook();
+    try {
+      this.hookRelease = acquireUiohook();
+      console.log("[hotkey] acquireUiohook() ok");
+    } catch (err) {
+      console.error("[hotkey] acquireUiohook() failed:", err);
+      uIOhook.off("keydown", this.downHandler);
+      uIOhook.off("keyup", this.upHandler);
+      uIOhook.off("keydown", probeKey);
+      uIOhook.off("mousemove", probeMouse);
+      throw err;
+    }
     this.started = true;
   }
 

--- a/desktop/dictation/whisper-backend.ts
+++ b/desktop/dictation/whisper-backend.ts
@@ -8,6 +8,8 @@ import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { asarUnpacked } from "../utils/asar-paths.ts";
+
 export type TranscribeResult = {
   text: string;
   language?: string;
@@ -200,7 +202,11 @@ export function parseDetectedLanguage(stderr: string): string | undefined {
 //   1. Bundled: `<dist>/desktop/dictation/{whisper-cli, ggml-small.bin}`
 //   2. Project-local: `<project_root>/.whisper/{bin/whisper-cli, models/ggml-small.bin}`
 //      — used in dev before `npm run setup:dictation` ran the rebuild.
-const distDictationDir = path.dirname(fileURLToPath(import.meta.url));
+// asarUnpacked() — `child_process.spawn` cannot descend into app.asar (#82).
+// The whisper model file is also referenced through this path because
+// whisper-cli loads it with fopen() — that's an OS syscall, not an Electron
+// fs call, so the asar→asar.unpacked redirect does not apply.
+const distDictationDirOnDisk = asarUnpacked(path.dirname(fileURLToPath(import.meta.url)));
 
 function firstExisting(candidates: string[]): string {
   for (const candidate of candidates) {
@@ -211,14 +217,16 @@ function firstExisting(candidates: string[]): string {
 
 function resolveDefaultBin(): string {
   return firstExisting([
-    path.join(distDictationDir, "whisper-cli"),
+    path.join(distDictationDirOnDisk, "whisper-cli"),
     path.join(process.cwd(), ".whisper", "bin", "whisper-cli")
   ]);
 }
 
 function resolveDefaultModel(): string {
+  // whisper-cli loads the model via its own fopen() call — that's also an
+  // OS-level path, so it needs the unpacked path too.
   return firstExisting([
-    path.join(distDictationDir, "ggml-small.bin"),
+    path.join(distDictationDirOnDisk, "ggml-small.bin"),
     path.join(process.cwd(), ".whisper", "models", "ggml-small.bin")
   ]);
 }

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -132,6 +132,7 @@ async function bootstrap(): Promise<void> {
     // their TCC prompts time out. Skipping these branches keeps the IPC
     // surface fully testable.
     if (process.env.MARSHAL_HEADLESS !== "1") {
+      logPermissionStatus();
       initTranslator();
       initCapture();
       initDictation();
@@ -898,12 +899,43 @@ async function showUpdateDialog(result: UpdateCheckOutcome): Promise<void> {
   }
 }
 
+/**
+ * Dump the macOS privacy gates dictation + capture depend on, so post-update
+ * regressions like #82 (silent uiohook because Input Monitoring was reset by
+ * the bundle swap) become diagnosable from the user's log. Runs unconditionally
+ * on every boot — cost is one system call per gate, output is four lines.
+ */
+function logPermissionStatus(): void {
+  if (process.platform !== "darwin") return;
+  try {
+    const mic = systemPreferences.getMediaAccessStatus("microphone");
+    const screen = systemPreferences.getMediaAccessStatus("screen");
+    // `false` means "don't show a prompt, just report the current state".
+    const a11y = systemPreferences.isTrustedAccessibilityClient(false);
+    console.log(`[marshal][perm] microphone=${mic}`);
+    console.log(`[marshal][perm] screen=${screen}`);
+    console.log(`[marshal][perm] accessibility=${a11y ? "granted" : "denied"}`);
+    // Input Monitoring has no first-party Electron API. Surface uiohook's
+    // observable behaviour instead — `[hotkey] start()` logs the next layer
+    // down, so a missing "hotkey start" line in the log means uiohook didn't
+    // attach (almost always = Input Monitoring not granted).
+    console.log(`[marshal][perm] input-monitoring=(no API — watch for "[hotkey] start" below)`);
+  } catch (err) {
+    console.warn("[marshal][perm] failed to query permissions:", err);
+  }
+}
+
 function initDictation(): void {
+  console.log("[marshal] initDictation()");
   const enabled = (process.env.MARSHAL_DICTATION_ENABLED ?? "1") !== "0";
-  if (!enabled) return;
+  if (!enabled) {
+    console.log("[marshal] dictation: MARSHAL_DICTATION_ENABLED=0 — skipping");
+    return;
+  }
 
   try {
     dictationService = new DictationService();
+    console.log("[marshal] dictation: service constructed");
   } catch (err) {
     console.warn("[marshal] dictation disabled:", err instanceof Error ? err.message : err);
     return;
@@ -928,7 +960,10 @@ function initDictation(): void {
     new Notification({ title: "Marshal — Dictation error", body: err.message, silent: true }).show();
   });
 
-  void dictationService.start();
+  console.log("[marshal] dictation: calling start()");
+  void dictationService.start()
+    .then(() => console.log("[marshal] dictation: start() resolved"))
+    .catch((err) => console.error("[marshal] dictation: start() rejected:", err));
 }
 
 function initCapture(): void {

--- a/desktop/translator/backends/apple-vision-backend.ts
+++ b/desktop/translator/backends/apple-vision-backend.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
+import { asarUnpacked } from "../../utils/asar-paths.ts";
 import { OpenAiApiTranslatorBackend } from "./openai-api-backend.ts";
 import { detectLangHeuristic, mimeExtension } from "./shared.ts";
 import type {
@@ -29,7 +30,8 @@ import type {
 const currentFilePath = fileURLToPath(import.meta.url);
 const backendsDir = path.dirname(currentFilePath);
 // backends/ → translator/ (one level up) → apple-vision-ocr binary.
-const DEFAULT_BIN = path.join(backendsDir, "..", "apple-vision-ocr");
+// asarUnpacked() — `child_process.spawn` cannot descend into app.asar (#82).
+const DEFAULT_BIN = path.join(asarUnpacked(path.join(backendsDir, "..")), "apple-vision-ocr");
 const OCR_BIN = process.env.MARSHAL_APPLE_VISION_BIN ?? DEFAULT_BIN;
 const OCR_TIMEOUT_MS = 10_000;
 const OCR_MAX_STDOUT_BYTES = 2 * 1024 * 1024;

--- a/desktop/translator/layout-switcher.ts
+++ b/desktop/translator/layout-switcher.ts
@@ -27,6 +27,8 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { asarUnpacked } from "../utils/asar-paths.ts";
+
 export const DEFAULT_LAYOUT_SWITCH_HOTKEY = "CommandOrControl+Alt+L";
 const COPY_COMMIT_DELAY_MS = 120;
 const BEFORE_PASTE_DELAY_MS = 40;
@@ -35,8 +37,9 @@ const SEND_KEY_TIMEOUT_MS = 3_000;
 
 // Path to the compiled Swift helper (see desktop/translator/send-keystroke.swift
 // + scripts/postbuild.mjs). Lives in the same dist folder as this module.
+// asarUnpacked() — `child_process.spawn` cannot descend into app.asar (#82).
 const currentFilePath = fileURLToPath(import.meta.url);
-const translatorDistDir = path.dirname(currentFilePath);
+const translatorDistDir = asarUnpacked(path.dirname(currentFilePath));
 const DEFAULT_SEND_KEY_BIN = path.join(translatorDistDir, "send-keystroke");
 const SEND_KEY_BIN = process.env.MARSHAL_SEND_KEY_BIN ?? DEFAULT_SEND_KEY_BIN;
 

--- a/desktop/utils/asar-paths.ts
+++ b/desktop/utils/asar-paths.ts
@@ -1,0 +1,23 @@
+// desktop/utils/asar-paths.ts
+//
+// Rewrite a path that lives inside `app.asar/` to its on-disk counterpart in
+// `app.asar.unpacked/`. Electron makes the asar archive transparent to
+// `fs.readFile` and friends via its asar→asar.unpacked redirect, but
+// `child_process.spawn` / `execFile` go straight to the OS `execve` syscall,
+// which cannot descend into a .asar file and fails with `ENOTDIR`.
+//
+// Any module that resolves a native helper binary from `import.meta.url` MUST
+// run that path through `asarUnpacked()` before handing it to `spawn`. In dev
+// builds (no asar at all) and in tests the function is a no-op, so callers
+// don't need to branch.
+//
+// Background: #82.
+
+import path from "node:path";
+
+const ASAR_SEGMENT = `${path.sep}app.asar${path.sep}`;
+const UNPACKED_SEGMENT = `${path.sep}app.asar.unpacked${path.sep}`;
+
+export function asarUnpacked(p: string): string {
+  return p.includes(ASAR_SEGMENT) ? p.replace(ASAR_SEGMENT, UNPACKED_SEGMENT) : p;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-chatgpt-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "local-chatgpt-agent",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-chatgpt-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "description": "Local autonomous agent that uses the ChatGPT web UI via Playwright as its reasoning engine.",

--- a/tests/asar-paths.test.ts
+++ b/tests/asar-paths.test.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { asarUnpacked } from "../desktop/utils/asar-paths.ts";
+
+describe("asarUnpacked", () => {
+  it("rewrites paths inside app.asar to app.asar.unpacked", () => {
+    expect(
+      asarUnpacked("/Applications/Marshal.app/Contents/Resources/app.asar/dist/desktop/dictation")
+    ).toBe(
+      "/Applications/Marshal.app/Contents/Resources/app.asar.unpacked/dist/desktop/dictation"
+    );
+  });
+
+  it("leaves dev paths untouched", () => {
+    const dev = "/Users/me/htdocs/marshal/dist/desktop/dictation";
+    expect(asarUnpacked(dev)).toBe(dev);
+  });
+
+  it("only rewrites the app.asar segment (not lookalikes)", () => {
+    // A dir literally named "app.asar.unpacked" — we must not double-rewrite.
+    const already =
+      "/Applications/Marshal.app/Contents/Resources/app.asar.unpacked/dist";
+    expect(asarUnpacked(already)).toBe(already);
+  });
+
+  it("is a no-op for paths without the asar segment", () => {
+    expect(asarUnpacked("/tmp/foo/bar")).toBe("/tmp/foo/bar");
+    expect(asarUnpacked("")).toBe("");
+  });
+
+  it("uses path.sep so the rewrite works on Windows-shaped paths too", () => {
+    // Synthesize a fake Windows path. asarUnpacked uses path.sep, which on
+    // posix is "/" — this still exercises the include() guard and ensures we
+    // don't accidentally match across separators.
+    const sep = path.sep;
+    const input = `C:${sep}Apps${sep}Marshal${sep}resources${sep}app.asar${sep}dist`;
+    const expected = `C:${sep}Apps${sep}Marshal${sep}resources${sep}app.asar.unpacked${sep}dist`;
+    expect(asarUnpacked(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Voice dictation has been dead in every packaged release since v0.1.4. Two overlapping bugs masked each other; this PR fixes the spawn one and ships the diagnostics that exposed it.

### Root cause

1. **TCC reset every self-signed update** (#84): each rebuild has a fresh code-directory hash, so Input Monitoring/Microphone consent is silently revoked. The user just experiences a dead hotkey. Tracked separately — long-term fix is notarization (#78).
2. **`spawn` can't descend into app.asar**: every native helper (audio-recorder, whisper-cli, screen-recorder, scroll-capture/stitch, apple-vision-ocr, send-keystroke) was resolved via `import.meta.url`, which in a packaged build lands at `app.asar/dist/.../<binary>`. Electron's asar→asar.unpacked redirect only covers `fs.*` — `execve` fails with `ENOTDIR` because `app.asar` is a file. Confirmed in the field: `[dictation] downHandler threw: Error: spawn ENOTDIR`.

### Fix

- New `desktop/utils/asar-paths.ts` exports `asarUnpacked(p)` — rewrites `…/app.asar/…` to `…/app.asar.unpacked/…`. No-op in dev / for paths without the segment.
- All seven spawn-target lookups now flow through it.
- Startup diagnostics in `main.ts`: Microphone / Screen / Accessibility status logged on every boot.
- `[hotkey] start()` and `[dictation] start()` now log unconditionally (without `MARSHAL_DICTATION_DEBUG=1`). A keydown/mousemove probe in `hotkey-manager.ts` distinguishes "TCC denies keystrokes" from "uiohook loop dead" — the difference that unblocked diagnosis.
- Version bumped to 0.1.7.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 212 tests passing (5 new for `asarUnpacked`)
- [x] Manual: built v0.1.7, replaced /Applications/Marshal.app, confirmed in log:
  - `[hotkey] start() keycode=3676`
  - `[hotkey] acquireUiohook() ok`
  - `[hotkey][probe] FIRST mousemove received`
- [ ] Manual: full end-to-end dictation (in flight as of merge — depends on user re-granting Input Monitoring after the bundle swap; tracked in #84).

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)