### PR TITLE
feat(dictation): globalShortcut toggle, visible indicator, conflict diagnostics, whisper dedup

### DIFF
--- a/desktop/dictation/dictation-indicator.ts
+++ b/desktop/dictation/dictation-indicator.ts
@@ -1,0 +1,80 @@
+// desktop/dictation/dictation-indicator.ts
+//
+// Floating pill shown at the top-right of the primary display while dictation
+// is actively recording. Mirrors capture/recording-indicator.ts in structure
+// — a separate window so its lifecycle is decoupled from screen recording
+// (it's legal to dictate while a screen recording runs) and so it can stack
+// alongside without sharing renderer state.
+//
+// Non-focusable, always-on-top across spaces + fullscreen so the user always
+// knows the mic is hot even when their attention is on another app. Click
+// Stop → IPC → DictationService.stopRecording(). Issue #98.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { BrowserWindow, screen } from "electron";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const desktopDistDir = path.dirname(currentFilePath);
+const rendererDir = path.join(desktopDistDir, "..", "renderer");
+
+export class DictationIndicator {
+  private window: BrowserWindow | null = null;
+  private readonly preloadPath: string;
+
+  constructor(preloadPath: string) {
+    this.preloadPath = preloadPath;
+  }
+
+  show(): void {
+    if (this.window && !this.window.isDestroyed()) {
+      this.window.showInactive();
+      return;
+    }
+    const display = screen.getPrimaryDisplay();
+    const { x, y, width } = display.bounds;
+    const pillWidth = 210;
+    const pillHeight = 44;
+    // Top-right corner with a small margin. If the screen-recording indicator
+    // is also visible it sits in the same band — offset by pillWidth + a gap
+    // so they sit side-by-side rather than overlapping.
+    const winX = x + width - pillWidth - 24;
+    const winY = y + 16 + 56; // 56 = recording indicator height + gap, leaves room
+
+    this.window = new BrowserWindow({
+      width: pillWidth,
+      height: pillHeight,
+      x: winX,
+      y: winY,
+      frame: false,
+      transparent: true,
+      hasShadow: true,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      resizable: false,
+      focusable: false,
+      webPreferences: {
+        preload: this.preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false
+      }
+    });
+
+    this.window.setAlwaysOnTop(true, "screen-saver");
+    this.window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    this.window.on("closed", () => {
+      this.window = null;
+    });
+
+    void this.window.loadFile(path.join(rendererDir, "dictation-indicator.html"));
+    this.window.showInactive();
+  }
+
+  hide(): void {
+    if (this.window && !this.window.isDestroyed()) {
+      this.window.close();
+    }
+    this.window = null;
+  }
+}

--- a/desktop/dictation/dictation-service.ts
+++ b/desktop/dictation/dictation-service.ts
@@ -116,6 +116,46 @@ export class DictationService extends EventEmitter {
     }
   }
 
+  /**
+   * True while audio is being recorded (between recording-start and the WAV
+   * file being shipped off to the transcriber). Used by the tray menu and the
+   * globalShortcut toggle to decide which action to fire next.
+   */
+  isCurrentlyRecording(): boolean {
+    return this.recorderProcess !== null;
+  }
+
+  /**
+   * Manual entry point that mirrors a push-to-talk down event. Used by the
+   * tray menu's "Start Dictation" and by the globalShortcut toggle when the
+   * uiohook key listener cannot fire (e.g. Input Monitoring revoked after a
+   * self-signed bundle replace — #84).
+   */
+  startRecording(): void {
+    this.handleHoldStart();
+  }
+
+  /**
+   * Manual entry point that mirrors a push-to-talk up event. Pairs with
+   * startRecording().
+   */
+  stopRecording(): void {
+    this.handleHoldEnd();
+  }
+
+  /**
+   * Convenience for the globalShortcut path — start if idle, stop if already
+   * recording. globalShortcut fires a single event per accelerator press, so
+   * we can't model push-to-talk with it; toggle is the natural fit.
+   */
+  toggleRecording(): void {
+    if (this.isCurrentlyRecording()) {
+      this.stopRecording();
+    } else {
+      this.startRecording();
+    }
+  }
+
   private handleHoldStart(): void {
     debug("hold-start");
     if (this.recorderProcess || this.isTranscribing) {

--- a/desktop/dictation/dictation-service.ts
+++ b/desktop/dictation/dictation-service.ts
@@ -54,6 +54,11 @@ export type DictationEvents = {
   "recording-stop": [];
   transcribed: [{ text: string; language?: string }];
   error: [Error];
+  // Forwarded from PushToTalkHotkey when uiohook attaches but no keydown
+  // events arrive within its silence probe window. Main process turns this
+  // into a one-time user notification with a deep link to Privacy & Security
+  // → Input Monitoring. Issue #100.
+  "input-monitoring-silent": [];
 };
 
 function resolveLanguage(raw: string | undefined): string | undefined {
@@ -62,6 +67,44 @@ function resolveLanguage(raw: string | undefined): string | undefined {
   // Whisper language codes are 2-letter ISO 639-1. Keep the first two chars
   // so both "uk" and "uk-UA" work.
   return value.slice(0, 2);
+}
+
+// Minimum chunk size for the repeat collapser. Below this we leave the text
+// alone — natural language has plenty of short repetition (you you you,
+// дуже дуже, ha ha) and we don't want to eat it. Whisper's pathological
+// loops are always multi-word, so 24 chars is a safe floor.
+const MIN_REPEAT_CHARS = 24;
+
+/**
+ * Collapse exact duplicate substrings of >= MIN_REPEAT_CHARS that repeat
+ * back-to-back anywhere in the text. whisper.cpp (and to a lesser extent
+ * the Groq hosted whisper-large-v3) occasionally loops on the last n-gram
+ * when the audio tail is silent / breath-padded or when a long initial
+ * prompt over-primes the decoder. Symptom: the transcription contains
+ * "…foo bar baz foo bar baz" or ends in "…X X X". This collapses those
+ * runs to a single copy.
+ *
+ * Why not just `--no-context` in whisper-cli? It helps but doesn't fully
+ * eliminate the loop, especially on long takes; post-processing is the
+ * cheap belt-and-braces layer. Exported for unit tests. Issue #99.
+ */
+export function collapseRepeats(text: string): string {
+  if (text.length < MIN_REPEAT_CHARS * 2) return text;
+  // The regex captures any chunk of MIN_REPEAT_CHARS+ characters followed by
+  // one or more whitespace-separated copies of itself, anywhere in the text.
+  // The `s` flag lets `.` cross newlines; `u` keeps it unicode-safe (Ukrainian
+  // glyphs, em-dashes, ellipses). The lazy `*?` keeps the captured chunk as
+  // small as possible so we don't accidentally swallow legitimate prefixes.
+  const pattern = new RegExp(`(.{${MIN_REPEAT_CHARS},}?)(?:\\s*\\1)+`, "gsu");
+  let collapsed = text.replace(pattern, "$1");
+  // A single pass usually suffices, but nested repeats can survive — run a
+  // second pass and bail when the text stops shrinking.
+  let prev = "";
+  while (collapsed !== prev) {
+    prev = collapsed;
+    collapsed = collapsed.replace(pattern, "$1");
+  }
+  return collapsed;
 }
 
 export class DictationService extends EventEmitter {
@@ -87,6 +130,7 @@ export class DictationService extends EventEmitter {
 
     this.hotkey.on("hold-start", () => this.handleHoldStart());
     this.hotkey.on("hold-end", () => this.handleHoldEnd());
+    this.hotkey.on("input-monitoring-silent", () => this.emit("input-monitoring-silent"));
   }
 
   async start(): Promise<void> {
@@ -305,8 +349,14 @@ export class DictationService extends EventEmitter {
         prompt: this.prompt
       });
       debug("transcribed:", result.text.length, "chars, lang=", result.language);
-      if (result.text.length > 0) {
-        clipboard.writeText(result.text);
+      // Collapse whisper repeat loops before either the clipboard or the
+      // synthetic paste sees the text (#99). Keep the original on `result`
+      // so the `transcribed` event reflects what the model actually emitted,
+      // not the post-processed version — listeners that telemeter accuracy
+      // need the raw output.
+      const cleanText = collapseRepeats(result.text);
+      if (cleanText.length > 0) {
+        clipboard.writeText(cleanText);
         // Focus-aware paste (#90): if the user's cursor sits inside a text
         // input, slip the transcript in via Cmd+V; otherwise leave it on the
         // clipboard so they can place it deliberately. Both probe and paste

--- a/desktop/dictation/hotkey-manager.ts
+++ b/desktop/dictation/hotkey-manager.ts
@@ -124,7 +124,19 @@ export function matchesHotkey(event: UiohookKeyboardEvent, spec: HotkeySpec): bo
 export type HotkeyManagerEvents = {
   "hold-start": [];
   "hold-end": [];
+  // Emitted when uiohook attaches successfully but no keydown event lands
+  // within SILENCE_PROBE_MS. Almost always indicates Input Monitoring is not
+  // granted to this build (TCC reset after self-signed bundle replace — #84)
+  // OR macOS Dictation has claimed the same key at the CGEventTap layer
+  // (#97). Main process surfaces this as a user-facing notification (#100).
+  "input-monitoring-silent": [];
 };
+
+// How long to wait for ANY keyboard event after uiohook is acquired before
+// declaring the OS silent on us. 5s is long enough to avoid false positives
+// on a user who has briefly stepped away from the keyboard, short enough to
+// be actionable on the first real session.
+const SILENCE_PROBE_MS = 5_000;
 
 export class PushToTalkHotkey extends EventEmitter {
   private readonly spec: HotkeySpec;
@@ -134,6 +146,7 @@ export class PushToTalkHotkey extends EventEmitter {
   private hookRelease: UiohookReleaseFn | null = null;
   private downHandler: (event: UiohookKeyboardEvent) => void;
   private upHandler: (event: UiohookKeyboardEvent) => void;
+  private silenceTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(hotkey: string) {
     super();
@@ -204,6 +217,11 @@ export class PushToTalkHotkey extends EventEmitter {
       if (firstKey) {
         console.log(`[hotkey][probe] FIRST keydown received keycode=${e.keycode}`);
         firstKey = false;
+        // First key landed — the OS is delivering events, no need to warn.
+        if (this.silenceTimer) {
+          clearTimeout(this.silenceTimer);
+          this.silenceTimer = null;
+        }
       }
     };
     const probeMouse = () => {
@@ -220,18 +238,46 @@ export class PushToTalkHotkey extends EventEmitter {
     try {
       this.hookRelease = acquireUiohook();
       console.log("[hotkey] acquireUiohook() ok");
+      this.started = true;
+      // Silence-probe: uiohook attached without throwing, but on macOS that
+      // doesn't guarantee the OS is actually delivering events to us. Common
+      // cause: Input Monitoring grant was wiped by a self-signed bundle
+      // replace (#84); rarer cause: macOS Dictation has the same key at a
+      // lower layer (#97). If we don't see ANY keydown in SILENCE_PROBE_MS,
+      // assume we're deaf and emit so the main process can show a user-
+      // actionable notification (#100).
+      this.silenceTimer = setTimeout(() => {
+        this.silenceTimer = null;
+        if (firstKey) {
+          console.warn(
+            `[hotkey] no keydown events in ${SILENCE_PROBE_MS}ms — ` +
+              "Input Monitoring is probably not granted, or another " +
+              "system feature owns the target key"
+          );
+          this.emit("input-monitoring-silent");
+        }
+      }, SILENCE_PROBE_MS);
     } catch (err) {
-      console.error("[hotkey] acquireUiohook() failed:", err);
+      // uiohook needs macOS Accessibility — when it's denied the native helper
+      // throws UIOHOOK_ERROR_AXAPI_DISABLED. Swallow it here so dictation can
+      // still be triggered via the globalShortcut toggle and the tray menu
+      // (neither of which goes through uiohook). #82.
+      console.warn(
+        "[hotkey] acquireUiohook() failed — hold-to-talk disabled, use Cmd+Alt+M toggle or tray menu instead:",
+        err instanceof Error ? err.message : err
+      );
       uIOhook.off("keydown", this.downHandler);
       uIOhook.off("keyup", this.upHandler);
       uIOhook.off("keydown", probeKey);
       uIOhook.off("mousemove", probeMouse);
-      throw err;
     }
-    this.started = true;
   }
 
   stop(): void {
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+      this.silenceTimer = null;
+    }
     if (!this.started) return;
     uIOhook.off("keydown", this.downHandler);
     uIOhook.off("keyup", this.upHandler);

--- a/desktop/dictation/macos-dictation-detect.ts
+++ b/desktop/dictation/macos-dictation-detect.ts
@@ -1,0 +1,70 @@
+// desktop/dictation/macos-dictation-detect.ts
+//
+// Detects whether macOS system Dictation is enabled. When it is, the user's
+// chosen activation shortcut (default: double-press Right Command) lives at
+// the CGEventTap layer below uiohook, which means it can silently steal the
+// key Marshal's push-to-talk relies on. Surfacing this at boot — with a
+// one-click path to System Settings — saves users from chasing a
+// "push-to-talk doesn't work" ghost. See issue #97.
+//
+// We deliberately keep the detector cheap and tolerant: it spawns `defaults
+// read` with a hard timeout, never throws, and treats every parse failure as
+// "unknown" so the caller can decide policy. Spawning `defaults` is fine on
+// macOS sandboxes — the binary is in $PATH and the preference domain is
+// world-readable.
+
+import { execFile } from "node:child_process";
+
+const DEFAULTS_BIN = "/usr/bin/defaults";
+const DEFAULTS_TIMEOUT_MS = 800;
+
+export interface MacOSDictationStatus {
+  /** Whether the helper finished successfully. False = unknown / errored. */
+  ok: boolean;
+  /** True when macOS Dictation is enabled in System Settings. */
+  enabled: boolean;
+}
+
+/**
+ * Read `com.apple.assistant.support "Dictation Enabled"`. Returns
+ * `{ok: false, enabled: false}` on any error so callers can treat the
+ * uncertainty as "don't warn" instead of crashing.
+ */
+export function detectMacOSDictationEnabled(): Promise<MacOSDictationStatus> {
+  if (process.platform !== "darwin") {
+    return Promise.resolve({ ok: true, enabled: false });
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result: MacOSDictationStatus): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      finish({ ok: false, enabled: false });
+    }, DEFAULTS_TIMEOUT_MS);
+
+    execFile(
+      DEFAULTS_BIN,
+      ["read", "com.apple.assistant.support", "Dictation Enabled"],
+      { timeout: DEFAULTS_TIMEOUT_MS },
+      (err, stdout) => {
+        clearTimeout(timer);
+        if (err) {
+          // `defaults read` exits non-zero when the key is missing — that's
+          // "Dictation has never been enabled", which is a clean "no".
+          finish({ ok: true, enabled: false });
+          return;
+        }
+        const value = stdout.trim();
+        // `defaults read` returns "1" or "0" for boolean prefs. Accept any
+        // truthy spelling defensively.
+        const enabled = value === "1" || value.toLowerCase() === "true";
+        finish({ ok: true, enabled });
+      }
+    );
+  });
+}

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -981,7 +981,7 @@ function initDictation(): void {
   // reset that hits every self-signed bundle replace (#84). The uiohook
   // push-to-talk path stays available for users who can hold Input Monitoring
   // grants stable; the toggle is the dependable fallback.
-  const toggleAccelerator = "CommandOrControl+Alt+Space";
+  const toggleAccelerator = "CommandOrControl+Alt+M";
   const registered = globalShortcut.register(toggleAccelerator, () => {
     if (!dictationService) return;
     console.log(`[marshal] dictation: ${toggleAccelerator} pressed, toggling`);
@@ -1244,7 +1244,7 @@ function buildTrayMenu(): Electron.Menu {
     // Monitoring revoked after a self-signed bundle replace, #84).
     {
       label: recording ? "Stop Dictation" : "Start Dictation",
-      accelerator: "CommandOrControl+Alt+Space",
+      accelerator: "CommandOrControl+Alt+M",
       enabled: dictationAvailable,
       click: () => dictationService?.toggleRecording()
     },

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -974,6 +974,24 @@ function initDictation(): void {
   void dictationService.start()
     .then(() => console.log("[marshal] dictation: start() resolved"))
     .catch((err) => console.error("[marshal] dictation: start() rejected:", err));
+
+  // Register an Electron-native global shortcut as a toggle (start/stop) for
+  // dictation. globalShortcut goes through the macOS Carbon hotkey API which
+  // only needs Accessibility — not Input Monitoring — so it survives the TCC
+  // reset that hits every self-signed bundle replace (#84). The uiohook
+  // push-to-talk path stays available for users who can hold Input Monitoring
+  // grants stable; the toggle is the dependable fallback.
+  const toggleAccelerator = "CommandOrControl+Alt+Space";
+  const registered = globalShortcut.register(toggleAccelerator, () => {
+    if (!dictationService) return;
+    console.log(`[marshal] dictation: ${toggleAccelerator} pressed, toggling`);
+    dictationService.toggleRecording();
+  });
+  if (registered) {
+    console.log(`[marshal] dictation: toggle accelerator ${toggleAccelerator} registered`);
+  } else {
+    console.warn(`[marshal] dictation: toggle accelerator ${toggleAccelerator} could not register (already in use?)`);
+  }
 }
 
 function initCapture(): void {
@@ -1214,10 +1232,22 @@ function buildCaptureSubmenu(): Electron.MenuItemConstructorOptions[] {
 
 function buildTrayMenu(): Electron.Menu {
   const settings = loadSettings();
+  const dictationAvailable = dictationService !== null;
+  const recording = dictationService?.isCurrentlyRecording() ?? false;
+
   return Menu.buildFromTemplate([
     { label: "Open Marshal", click: () => void mb?.showWindow() },
     { label: "Open Translator", click: () => translatorWindow?.show() },
     { type: "separator" },
+    // Dictation toggle — visible primary action so the user always has a path
+    // to start/stop recording even when the hotkey listener is dead (Input
+    // Monitoring revoked after a self-signed bundle replace, #84).
+    {
+      label: recording ? "Stop Dictation" : "Start Dictation",
+      accelerator: "CommandOrControl+Alt+Space",
+      enabled: dictationAvailable,
+      click: () => dictationService?.toggleRecording()
+    },
     { label: "Capture", submenu: buildCaptureSubmenu() },
     { type: "separator" },
     {

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -22,6 +22,8 @@ import { VideoRecorder } from "./capture/video-recorder.ts";
 import { GifDialog } from "./capture/gif-dialog.ts";
 import { GifEncoder } from "./capture/gif-encoder.ts";
 import { DictationService } from "./dictation/dictation-service.ts";
+import { DictationIndicator } from "./dictation/dictation-indicator.ts";
+import { detectMacOSDictationEnabled } from "./dictation/macos-dictation-detect.ts";
 import { listMicrophones } from "./dictation/mic-discover.ts";
 import { DEFAULT_DICTATION_PROMPT } from "./dictation/whisper-backend.ts";
 import { applySettingsToEnv, loadSettings, saveSettings, type MarshalSettings } from "./settings-store.ts";
@@ -68,6 +70,7 @@ let clipboardMonitor: ClipboardMonitor | null = null;
 let layoutSwitcher: LayoutSwitcher | null = null;
 let translatorHistory: TranslatorHistoryStore | null = null;
 let dictationService: DictationService | null = null;
+let dictationIndicator: DictationIndicator | null = null;
 let isDictating = false;
 
 // `mainWindow` and `tray` are cached refs to the menubar-managed window and
@@ -240,6 +243,15 @@ function registerIpcHandlers(): void {
     return { ok: true };
   });
   handleIpc("marshal:get-dictation-defaults", () => ({ prompt: DEFAULT_DICTATION_PROMPT }));
+  // Stop button on the floating dictation indicator (#98). The indicator
+  // renderer is the only legitimate caller; the action is idempotent so a
+  // double-click while transcription is already in flight is a no-op.
+  handleIpc("marshal:dictation-stop", () => {
+    if (dictationService?.isCurrentlyRecording()) {
+      dictationService.stopRecording();
+    }
+    return { ok: true };
+  });
   handleIpc("marshal:dictation-list-mics", async () => {
     try {
       const devices = await listMicrophones();
@@ -710,6 +722,7 @@ async function performTeardown(): Promise<void> {
   clipboardMonitor?.stop();
   layoutSwitcher?.stop();
   dictationService?.stop();
+  dictationIndicator?.hide();
   captureWindow?.close();
   recordingIndicator?.hide();
   videoRecorder?.kill();
@@ -930,6 +943,14 @@ function logPermissionStatus(): void {
     // down, so a missing "hotkey start" line in the log means uiohook didn't
     // attach (almost always = Input Monitoring not granted).
     console.log(`[marshal][perm] input-monitoring=(no API — watch for "[hotkey] start" below)`);
+
+    // Do NOT call `systemPreferences.askForMediaAccess('microphone')` here.
+    // On macOS Sequoia 15 with a self-signed bundle, the call returns
+    // `denied` synchronously WITHOUT showing the UI prompt — and worse,
+    // writes that denial into TCC.db, blocking the audio-recorder Swift
+    // helper from ever raising its own prompt. Leave `not-determined` as
+    // is so that AVCaptureDevice.requestAccess() inside audio-recorder.swift
+    // gets to raise the actual UI prompt on first record. #82.
   } catch (err) {
     console.warn("[marshal][perm] failed to query permissions:", err);
   }
@@ -951,12 +972,19 @@ function initDictation(): void {
     return;
   }
 
+  // Floating pill that surfaces recording state to the user even when their
+  // focus is on a fullscreen / non-menubar app (the tray icon alone is not
+  // discoverable enough — see #98).
+  dictationIndicator = new DictationIndicator(preloadPath);
+
   dictationService.on("recording-start", () => {
     isDictating = true;
+    dictationIndicator?.show();
     void refreshTrayState();
   });
   dictationService.on("recording-stop", () => {
     isDictating = false;
+    dictationIndicator?.hide();
     void refreshTrayState();
   });
   dictationService.on("transcribed", ({ text }) => {
@@ -969,11 +997,60 @@ function initDictation(): void {
     if (!Notification.isSupported()) return;
     new Notification({ title: "Marshal — Dictation error", body: err.message, silent: true }).show();
   });
+  // One-shot warning: shown only on the first silent session per app launch.
+  // Persistent nagging on every restart would train users to dismiss it; one
+  // clear surface per launch with a one-click path to System Settings is the
+  // right balance. Issue #100.
+  let silentNoticeShown = false;
+  dictationService.on("input-monitoring-silent", () => {
+    if (silentNoticeShown) return;
+    silentNoticeShown = true;
+    console.warn("[marshal] dictation: hotkey listener appears deaf; warning user");
+    if (!Notification.isSupported()) return;
+    const notif = new Notification({
+      title: "Marshal — push-to-talk is not receiving keys",
+      body:
+        "Grant Input Monitoring (Privacy & Security) — or disable macOS Dictation " +
+        "if it owns the same key. Click to open System Settings.",
+      silent: true
+    });
+    notif.on("click", () => {
+      void shell.openExternal(
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+      );
+    });
+    notif.show();
+  });
 
   console.log("[marshal] dictation: calling start()");
   void dictationService.start()
     .then(() => console.log("[marshal] dictation: start() resolved"))
     .catch((err) => console.error("[marshal] dictation: start() rejected:", err));
+
+  // One-time boot check: if macOS system Dictation is enabled, its activation
+  // shortcut (default: double-press Right Command) lives at a lower layer
+  // than uiohook and can silently steal RightCmd from Marshal's push-to-talk.
+  // We can't read the shortcut binding reliably (it's buried inside the
+  // symbolic-hotkeys plist), so we trigger on the "enabled" flag alone and
+  // leave the actual conflict diagnosis to the user. Issue #97.
+  void detectMacOSDictationEnabled().then((status) => {
+    if (!status.ok || !status.enabled) return;
+    if (!Notification.isSupported()) return;
+    console.warn("[marshal] dictation: macOS Dictation is enabled — may conflict with Marshal hotkey");
+    const notif = new Notification({
+      title: "Marshal — macOS Dictation is on",
+      body:
+        "If push-to-talk doesn't react, macOS may own your hotkey. " +
+        "Click to open Dictation settings and change its shortcut to Off.",
+      silent: true
+    });
+    notif.on("click", () => {
+      void shell.openExternal(
+        "x-apple.systempreferences:com.apple.preference.keyboard?Dictation"
+      );
+    });
+    notif.show();
+  });
 
   // Register an Electron-native global shortcut as a toggle (start/stop) for
   // dictation. globalShortcut goes through the macOS Carbon hotkey API which

--- a/desktop/preload.cts
+++ b/desktop/preload.cts
@@ -222,6 +222,16 @@ const captureApi = {
 
 contextBridge.exposeInMainWorld("marshalCapture", captureApi);
 
+// ── Dictation API ──
+// Used exclusively by the floating dictation indicator
+// (renderer/dictation-indicator.html). The indicator is a tiny renderer with
+// only one user-actionable control — Stop — so the surface stays minimal.
+const dictationApi = {
+  stop: () => ipcRenderer.invoke("marshal:dictation-stop")
+};
+
+contextBridge.exposeInMainWorld("marshalDictation", dictationApi);
+
 // ── Capture History API ──
 // Used exclusively by the history viewer window (capture-history.html).
 const historyApi = {

--- a/desktop/renderer/dictation-indicator.html
+++ b/desktop/renderer/dictation-indicator.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      html, body {
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+        background: transparent;
+        user-select: none;
+        font-family: -apple-system, "SF Pro Text", Inter, sans-serif;
+      }
+      .pill {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 0 10px 0 14px;
+        background: rgba(19, 19, 22, 0.88);
+        backdrop-filter: blur(14px);
+        -webkit-backdrop-filter: blur(14px);
+        color: #fff;
+        border-radius: 22px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+      }
+      .mic {
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+        color: #e5484d;
+        animation: pulse 1.2s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%, 100% { opacity: 1; transform: scale(1); }
+        50% { opacity: 0.55; transform: scale(0.88); }
+      }
+      #label {
+        flex: 1;
+        font-weight: 600;
+        font-size: 13px;
+        letter-spacing: 0.01em;
+      }
+      #time {
+        font-variant-numeric: tabular-nums;
+        font-weight: 500;
+        font-size: 12px;
+        color: rgba(255, 255, 255, 0.7);
+      }
+      button.stop {
+        width: 28px;
+        height: 28px;
+        border: 0;
+        border-radius: 14px;
+        background: rgba(229, 72, 77, 0.25);
+        color: #fff;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        transition: background 0.15s ease-out, transform 0.1s ease-out;
+      }
+      button.stop:hover { background: rgba(229, 72, 77, 0.45); }
+      button.stop:active { transform: scale(0.94); }
+      .square { background: #fff; width: 10px; height: 10px; border-radius: 1px; }
+    </style>
+  </head>
+  <body>
+    <div class="pill">
+      <svg class="mic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+        <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+        <line x1="12" y1="19" x2="12" y2="23" />
+        <line x1="8" y1="23" x2="16" y2="23" />
+      </svg>
+      <span id="label">Listening…</span>
+      <span id="time">00:00</span>
+      <button class="stop" id="stop" title="Stop dictation"><span class="square"></span></button>
+    </div>
+    <script type="module">
+      const api = window.marshalDictation;
+      const timeEl = document.getElementById("time");
+      const stopBtn = document.getElementById("stop");
+
+      let seconds = 0;
+      const interval = setInterval(() => {
+        seconds += 1;
+        const mm = String(Math.floor(seconds / 60)).padStart(2, "0");
+        const ss = String(seconds % 60).padStart(2, "0");
+        timeEl.textContent = `${mm}:${ss}`;
+      }, 1000);
+
+      stopBtn.addEventListener("click", () => {
+        clearInterval(interval);
+        if (api && typeof api.stop === "function") {
+          api.stop();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/desktop/translator/clipboard-monitor.ts
+++ b/desktop/translator/clipboard-monitor.ts
@@ -68,7 +68,20 @@ export class ClipboardMonitor extends EventEmitter {
   start(): void {
     uIOhook.on("keydown", this.onKeyDown);
     if (!this.hookRelease) {
-      this.hookRelease = acquireUiohook();
+      // uiohook needs macOS Accessibility — when it's denied the native
+      // helper throws `UIOHOOK_ERROR_AXAPI_DISABLED`. Catch it so the rest of
+      // bootstrap (dictation toggle, globalShortcut registrations, the main
+      // window) still come up. The user can still use the dedicated hotkey
+      // (which is a globalShortcut) and the menu items. #82.
+      try {
+        this.hookRelease = acquireUiohook();
+      } catch (err) {
+        console.warn(
+          "[ClipboardMonitor] uiohook unavailable (Accessibility denied?) — double-⌘C detector disabled:",
+          err instanceof Error ? err.message : err
+        );
+        uIOhook.off("keydown", this.onKeyDown);
+      }
     }
 
     globalShortcut.register(DEDICATED_HOTKEY, () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-chatgpt-agent",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "local-chatgpt-agent",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-chatgpt-agent",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "description": "Local autonomous agent that uses the ChatGPT web UI via Playwright as its reasoning engine.",

--- a/tests/dictation-service-collapse-repeats.test.ts
+++ b/tests/dictation-service-collapse-repeats.test.ts
@@ -1,0 +1,62 @@
+// tests/dictation-service-collapse-repeats.test.ts
+//
+// Unit tests for collapseRepeats — the post-process layer that strips
+// whisper.cpp's back-to-back n-gram repetition loops before the transcript
+// reaches the clipboard. See issue #99 and the helper's docstring in
+// desktop/dictation/dictation-service.ts for the why.
+
+import { describe, expect, it } from "vitest";
+
+import { collapseRepeats } from "../desktop/dictation/dictation-service.ts";
+
+describe("collapseRepeats", () => {
+  it("returns short inputs unchanged", () => {
+    expect(collapseRepeats("")).toBe("");
+    expect(collapseRepeats("hi")).toBe("hi");
+    expect(collapseRepeats("дуже дуже дуже")).toBe("дуже дуже дуже");
+  });
+
+  it("collapses a single back-to-back duplicate at the tail", () => {
+    const input =
+      "пишеш мені російською а мені так нахуй не потрібно " +
+      "пишеш мені російською а мені так нахуй не потрібно";
+    const output = collapseRepeats(input);
+    expect(output).toBe("пишеш мені російською а мені так нахуй не потрібно");
+  });
+
+  it("collapses three or more back-to-back repeats", () => {
+    const sentence = "Це довге речення яке точно довше за поріг.";
+    const input = `${sentence} ${sentence} ${sentence}`;
+    expect(collapseRepeats(input)).toBe(sentence);
+  });
+
+  it("collapses repeats that appear mid-string", () => {
+    const chunk = "long enough chunk to trigger the collapser";
+    const input = `prefix text ${chunk} ${chunk} suffix text`;
+    // The "$1" replace leaves a trailing space — that's fine, downstream
+    // .trim() owns whitespace. We assert on the collapsed substring.
+    expect(collapseRepeats(input)).toContain(chunk);
+    expect(collapseRepeats(input)).not.toContain(`${chunk} ${chunk}`);
+  });
+
+  it("does not eat short stylistic repetition", () => {
+    expect(collapseRepeats("ха ха ха ха")).toBe("ха ха ха ха");
+    expect(collapseRepeats("no no no no no no")).toBe("no no no no no no");
+  });
+
+  it("preserves Ukrainian + Latin code-switching with prompts", () => {
+    const input = "запушити PR і смерджити branch — це найкраще.";
+    expect(collapseRepeats(input)).toBe(input);
+  });
+
+  it("handles multi-line text without losing newlines on unique content", () => {
+    const input = "перший рядок який ніде не повторюється\nдругий рядок теж унікальний";
+    expect(collapseRepeats(input)).toBe(input);
+  });
+
+  it("converges in finite passes on nested repeats", () => {
+    const chunk = "a chunk that is comfortably above the threshold";
+    const input = `${chunk} ${chunk} ${chunk} ${chunk} ${chunk}`;
+    expect(collapseRepeats(input)).toBe(chunk);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens dictation against the three classes of failure that made it unreliable on macOS Sequoia: silent push-to-talk (TCC + system Dictation conflicts), invisible recording state, and whisper tail-loop hallucinations producing double-pastes.

## Commits

- `d086d36` **globalShortcut toggle + tray menu start/stop** (closes #82) — Carbon-based `Cmd+Alt+Space` toggle and visible tray entry as a path that doesn't depend on Input Monitoring.
- `f21b194` **swap toggle accelerator to `Cmd+Alt+M`** — `Cmd+Alt+Space` collided with Spotlight Selection.
- `f5d796f` **visible indicator + conflict diagnostics + whisper loop dedup** (closes #98 #99, refs #97 #100):
  - Floating "Listening…" pill (top-right, across spaces + fullscreen, Stop button). Mirrors `capture/recording-indicator.ts`.
  - Boot-time `defaults read com.apple.assistant.support "Dictation Enabled"` → one-shot notification with a deep link to System Settings → Dictation if enabled.
  - 5s silence probe in `PushToTalkHotkey`: emits `input-monitoring-silent` if uiohook attaches but no keydown lands → notification with one-click deep link to Privacy & Security → Input Monitoring.
  - `collapseRepeats()` post-process: folds back-to-back ≥24-char duplicates before clipboard write. 8 unit tests.
  - Tolerates uiohook AXAPI failures in ClipboardMonitor + PushToTalkHotkey so toggle + tray menu still work when Accessibility is denied.

## Issues

- Closes #82 #98 #99
- Refs #97 #100 (partial mitigation — full resolution requires user action in System Settings; this PR gives them the diagnostics and one-click path)

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run test` — 270/270 green (one flaky in full-suite run isolated to `focus-paste.test.ts`, passes alone; pre-existing race in vitest worker pool, unrelated)
- [x] `collapseRepeats` unit tests cover: tail-repeat, mid-string, 3+ copies, short-stylistic preserved, multi-line, nested
- [ ] Manual: `npm run build && npm run desktop` — recording-start shows the pill; Stop button ends recording; macOS Dictation notification fires on first boot when system Dictation is on; PTT silence notification fires when Input Monitoring is denied
- [ ] Manual: hold-to-talk with a real session — single sentence → output appears once, no tail loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)