### PR TITLE
fix(dev): stable codesign keeps macOS TCC grants persistent across rebuilds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,17 @@
 - Перед коммітом: `npm run check` (typecheck + test)
 
 ### First-run setup
+- **macOS codesign cert (ОБОВ'ЯЗКОВО для dev):**
+  1. `npm run setup:codesign-cert` — створює self-signed `Marshal Self-Signed` cert у keychain. Двічі попросить `sudo` (`security remove-trusted-cert` + `security add-trusted-cert`) — це нормально, скрипт надрукує точні команди.
+  2. Перевірка: `security find-identity -v -p codesigning | grep "Marshal Self-Signed"` — має бути хоча б один рядок без "Invalid Key Usage".
+  3. Чому це потрібно: без stable cert `npm run build` підписує bundle ad-hoc → новий CDHash щоразу → macOS TCC вважає це новим app → знову запитує Microphone/Screen Recording/Accessibility. Зі stable cert + фіксованим bundle ID `com.marshal.desktop.dev` grants зберігаються назавжди (див. #84).
+  4. Якщо TCC після переходу на stable cert все одно показує `com.github.Electron` зі старими grants: `tccutil reset All com.github.Electron && tccutil reset All com.marshal.desktop.dev`, після цього один раз `Allow` — і тиша.
 - Voice dictation:
   1. `npm run setup:dictation` (whisper.cpp + `ggml-small`, ~465 MB, у `.whisper/`)
   2. **macOS permissions для `npm run desktop` (dev mode):**
-     - `npm run build` автоматично патчить `node_modules/electron/dist/Electron.app/Contents/Info.plist` (додає `NSMicrophoneUsageDescription` + `NSScreenCaptureUsageDescription`) та ad-hoc re-signsить bundle — інакше macOS TCC вбиває наш Swift recorder. Скрипт: `scripts/patch-electron-info-plist.sh`, запускається з `postbuild.mjs`.
+     - `npm run build` автоматично патчить `node_modules/electron/dist/Electron.app/Contents/Info.plist` (додає `NSMicrophoneUsageDescription` + `NSScreenCaptureUsageDescription` + `CFBundleIdentifier=com.marshal.desktop.dev`), підписує bundle stable identity `Marshal Self-Signed` (якщо cert встановлений) і підписує всі Swift helpers (`audio-recorder`, `screen-recorder`, `scroll-capture`, `scroll-stitch`, `apple-vision-ocr`, `send-keystroke`) тією ж identity. Скрипти: `scripts/patch-electron-info-plist.sh` + `scripts/postbuild.mjs`.
      - При першому запуску системний prompt → **Allow** для Microphone (а також Accessibility для push-to-talk hotkey, якщо ще не ввімкнено).
-     - Після `npm install` треба один раз перезапустити `npm run desktop` — нові permission descriptions підхопить TCC.
-     - Packaged build отримує ті ж keys через `package.json > build.mac.extendInfo`.
+     - Packaged build отримує ті ж keys через `package.json > build.mac.extendInfo` + stable identity `099164E16AE88B2052B842BE1036FB10411B7239`.
   3. Debug: `MARSHAL_DICTATION_DEBUG=1 npm run desktop` — поаналізувати keydown/keyup/recorder state (див. #49, #50)
 - Translator: налаштувати `MARSHAL_API_KEY` у `.env` (див. `.env.example`)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "npm run build && node tests/e2e/smoke.mjs",
     "check": "npm run typecheck && npm run test",
-    "setup:dictation": "bash scripts/install-whisper-cpp.sh"
+    "setup:dictation": "bash scripts/install-whisper-cpp.sh",
+    "setup:codesign-cert": "bash scripts/setup-codesign-cert.sh"
   },
   "build": {
     "appId": "com.marshal.desktop",

--- a/scripts/patch-electron-info-plist.sh
+++ b/scripts/patch-electron-info-plist.sh
@@ -4,6 +4,12 @@
 # our child processes touch the microphone / screen. Without them dev recorder
 # gets SIGKILL'd on AVCaptureDevice.authorizationStatus (see #50).
 #
+# Also pins the bundle to a stable identifier + signs it with a stable
+# self-signed certificate (if present). Without this every `npm run build`
+# produces a fresh ad-hoc CDHash, which invalidates TCC grants — macOS keeps
+# re-prompting for Microphone / Screen Recording on every dev run (see #84).
+# Run `npm run setup:codesign-cert` once to provision the cert.
+#
 # Packaged builds already receive the same keys via electron-builder's
 # `build.mac.extendInfo` (package.json). This script is a no-op on non-macOS
 # and is idempotent on repeat runs.
@@ -17,6 +23,11 @@ fi
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP="$ROOT_DIR/node_modules/electron/dist/Electron.app"
 PLIST="$APP/Contents/Info.plist"
+# Distinct from the packaged release identifier (`com.marshal.desktop`) so dev
+# TCC grants live in their own slot and don't collide with an installed build.
+DEV_BUNDLE_ID="com.marshal.desktop.dev"
+DEV_BUNDLE_NAME="Marshal (Dev)"
+CERT_NAME="Marshal Self-Signed"
 
 if [[ ! -f "$PLIST" ]]; then
   # electron not installed yet — nothing to patch.
@@ -27,6 +38,9 @@ declare -a desired=(
   "NSMicrophoneUsageDescription:Marshal needs microphone access to transcribe your voice dictation."
   "NSScreenCaptureUsageDescription:Marshal captures a selected screen region for OCR translation."
   "NSAppleEventsUsageDescription:Marshal uses Apple Events for auto-paste after dictation."
+  "CFBundleIdentifier:$DEV_BUNDLE_ID"
+  "CFBundleName:$DEV_BUNDLE_NAME"
+  "CFBundleDisplayName:$DEV_BUNDLE_NAME"
 )
 
 patched=0
@@ -34,7 +48,6 @@ for entry in "${desired[@]}"; do
   key="${entry%%:*}"
   value="${entry#*:}"
   if /usr/libexec/PlistBuddy -c "Print :$key" "$PLIST" > /dev/null 2>&1; then
-    # Already present — make sure the value is current.
     current="$(/usr/libexec/PlistBuddy -c "Print :$key" "$PLIST")"
     if [[ "$current" != "$value" ]]; then
       /usr/libexec/PlistBuddy -c "Set :$key '$value'" "$PLIST"
@@ -46,11 +59,41 @@ for entry in "${desired[@]}"; do
   fi
 done
 
-if (( patched == 1 )); then
-  # Ad-hoc re-sign so macOS still accepts the modified bundle. Without this
-  # the system may refuse to launch it or ignore the plist changes because the
-  # original signature is now invalid.
-  codesign --force --deep --sign - "$APP" > /dev/null 2>&1 || true
-  echo "[patch-electron] Info.plist updated + ad-hoc re-signed."
-  echo "[patch-electron] First run will show a system Microphone prompt — click Allow."
+# Resolve a valid stable codesign identity. `security find-identity` lists
+# both valid and "Invalid Key Usage for policy" entries — only the valid one
+# can actually sign. Pick its SHA-1 hash so codesign targets it unambiguously
+# (multiple certs with the same CN may otherwise resolve to the wrong one).
+STABLE_IDENTITY=""
+resolved="$(
+  security find-identity -v -p codesigning 2>/dev/null \
+    | grep "$CERT_NAME" \
+    | grep -v "Invalid" \
+    | head -1 \
+    | awk '{print $2}' || true
+)"
+if [[ "$resolved" =~ ^[0-9A-F]{40}$ ]]; then
+  STABLE_IDENTITY="$resolved"
+fi
+
+# Re-sign whenever we touched the bundle, OR when a stable cert is available
+# (in case a previous run left an ad-hoc signature behind).
+if (( patched == 1 )) || [[ -n "$STABLE_IDENTITY" ]]; then
+  if [[ -n "$STABLE_IDENTITY" ]]; then
+    if codesign --force --deep --sign "$STABLE_IDENTITY" "$APP" > /dev/null 2>&1; then
+      echo "[patch-electron] Signed with stable identity ($CERT_NAME, $STABLE_IDENTITY)."
+      echo "[patch-electron] Bundle ID: $DEV_BUNDLE_ID — TCC grants will now persist across rebuilds."
+    else
+      echo "[patch-electron] WARN: stable signing failed, falling back to ad-hoc." >&2
+      codesign --force --deep --sign - "$APP" > /dev/null 2>&1 || true
+    fi
+  else
+    codesign --force --deep --sign - "$APP" > /dev/null 2>&1 || true
+    cat >&2 <<MSG
+[patch-electron] Bundle re-signed ad-hoc — macOS will re-prompt for permissions
+[patch-electron] on every rebuild. To make grants persist:
+[patch-electron]   npm run setup:codesign-cert
+[patch-electron] (one-time setup, see scripts/setup-codesign-cert.sh for the
+[patch-electron]  two manual sudo steps it prints).
+MSG
+  fi
 fi

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -133,6 +133,17 @@ if (process.platform === "darwin") {
     }
   ];
 
+  // Resolve stable codesign identity once for the whole batch. Without a
+  // stable signature each rebuild gives every helper a fresh CDHash, so macOS
+  // TCC treats them as new binaries and re-prompts for Microphone / Screen
+  // Recording on every dev run. See scripts/setup-codesign-cert.sh.
+  const stableIdentity = resolveStableCodesignIdentity();
+  if (stableIdentity) {
+    console.log(`[postbuild] Using stable codesign identity for Swift helpers: ${stableIdentity}`);
+  } else {
+    console.warn("[postbuild] No stable codesign identity found — Swift helpers will be ad-hoc signed. Run `npm run setup:codesign-cert` to fix.");
+  }
+
   for (const target of swiftTargets) {
     await fs.mkdir(path.dirname(target.out), { recursive: true });
     try {
@@ -140,18 +151,48 @@ if (process.platform === "darwin") {
       console.log(`[postbuild] ${target.label} compiled →`, target.out);
     } catch (err) {
       console.warn(`[postbuild] swiftc ${target.label} failed — ${target.fallbackNote}:`, err.message);
+      continue;
+    }
+    try {
+      const signArgs = stableIdentity
+        ? ["--force", "--sign", stableIdentity, "--timestamp=none", target.out]
+        : ["--force", "--sign", "-", target.out];
+      execFileSync("codesign", signArgs, { stdio: ["ignore", "ignore", "pipe"] });
+    } catch (err) {
+      console.warn(`[postbuild] codesign ${target.label} failed:`, err.message);
     }
   }
 
   // Patch the dev Electron.app Info.plist so TCC allows our Swift helpers to
-  // touch the microphone / screen. Packaged builds get these via
-  // build.mac.extendInfo — this is the dev-only equivalent. #50.
+  // touch the microphone / screen, and re-sign the bundle with the stable
+  // identity so its CDHash stays constant across rebuilds. Packaged builds
+  // get these via build.mac.extendInfo — this is the dev-only equivalent.
+  // See #50, #84.
   const patchScript = path.join(root, "scripts", "patch-electron-info-plist.sh");
   try {
     execFileSync("bash", [patchScript], { stdio: "inherit" });
   } catch (err) {
     console.warn("[postbuild] patch-electron-info-plist failed:", err.message);
   }
+}
+
+function resolveStableCodesignIdentity() {
+  if (process.platform !== "darwin") return null;
+  try {
+    const out = execFileSync("security", ["find-identity", "-v", "-p", "codesigning"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    for (const line of out.split("\n")) {
+      if (!line.includes("Marshal Self-Signed")) continue;
+      if (line.includes("Invalid")) continue;
+      const match = line.match(/\b([0-9A-F]{40})\b/);
+      if (match) return match[1];
+    }
+  } catch {
+    // security tool missing or no identities — fall through to null.
+  }
+  return null;
 }
 
 async function copyDirectory(sourceDir, targetDir) {


### PR DESCRIPTION
## Summary

- Dev `Electron.app` now signed with stable `Marshal Self-Signed` identity (auto-detected from keychain) instead of ad-hoc per build.
- Swift helpers (audio-recorder, screen-recorder, scroll-capture, scroll-stitch, apple-vision-ocr, send-keystroke) signed with the same identity right after `swiftc -O`.
- Dev bundle pinned to `CFBundleIdentifier = com.marshal.desktop.dev`, isolated from the packaged release's `com.marshal.desktop`.
- `npm run setup:codesign-cert` exposed for one-time first-run setup.
- CLAUDE.md first-run docs updated.

## Why

Ad-hoc signature → CDHash changes every rebuild → TCC invalidates Microphone / Screen Recording / Accessibility grants → macOS prompts on every `npm run desktop`, or worse silently denies and devs see dead hotkeys and dead microphone.

For self-signed bundles without a Team ID, TCC's Designated Requirement is `cdhash H"<hash>"` — the binary's own SHA-256. Stable certificate authority alone is not enough; we needed both the stable signature **and** a stable identifier so TCC has a consistent identity to remember.

## Verification

Two consecutive `npm run build` runs produce **identical CDHash** on every binary:

| Binary | CDHash |
|---|---|
| Electron.app | `b4fd7872882b9d8c0eac2017eeef6fac22d90ec7` |
| audio-recorder | `d73358b67d94cd65db6010bbc9dc28807122139b` |
| screen-recorder | `e5519fc2ce1c20b386da496d3cc3225dfb9ae625` |

`Authority=Marshal Self-Signed`, `Identifier=com.marshal.desktop.dev` (Electron.app).

`npm run check` green (typecheck + 212 tests passing).

## Test plan

- [ ] On a fresh machine: `npm run setup:codesign-cert`, follow the two `sudo` steps it prints, then `npm run desktop`
- [ ] Click Allow on the first Microphone prompt; quit; rebuild; relaunch
- [ ] Confirm **no second prompt** — TCC grant survives the rebuild
- [ ] Confirm voice dictation works (audio-recorder spawns, transcription returns)
- [ ] Confirm screen recording works (Cmd+Option+6, scroll capture)
- [ ] Confirm push-to-talk hotkey works (Accessibility grant survives)
- [ ] Run `codesign -dvvv node_modules/electron/dist/Electron.app | grep CDHash` twice → identical

## Notes for users with existing stale TCC grants

If you're upgrading and macOS still shows old `com.github.Electron` entries in System Settings → Privacy & Security, run once:

```bash
tccutil reset All com.github.Electron
tccutil reset All com.marshal.desktop.dev
```

Then `npm run desktop` → one final Allow per category → permanent peace.

Closes #88
Related to #84 (packaged-update flow has same root cause; that one ultimately needs Apple Developer ID notarization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)