### PR TITLE
feat(dictation): focus-aware paste — auto-insert when text field focused (#90)

### DIFF
--- a/desktop/dictation/dictation-service.ts
+++ b/desktop/dictation/dictation-service.ts
@@ -21,6 +21,7 @@ import { clipboard } from "electron";
 
 import { PushToTalkHotkey } from "./hotkey-manager.ts";
 import { asarUnpacked } from "../utils/asar-paths.ts";
+import { probeFocusedElement, sendPasteKeystroke } from "./focus-paste.ts";
 import {
   createWhisperBackend,
   resolveBackendName,
@@ -194,6 +195,21 @@ export class DictationService extends EventEmitter {
     }
   }
 
+  private async maybeAutoPaste(): Promise<void> {
+    const focus = await probeFocusedElement();
+    if (!focus.isTextInput) {
+      debug("no editable focus — clipboard only (role=", focus.role || "?", ")");
+      return;
+    }
+    debug("focused element accepts text — auto-pasting (role=", focus.role, ")");
+    try {
+      await sendPasteKeystroke();
+    } catch (err) {
+      // Don't surface as a fatal error — clipboard fallback is still usable.
+      debug("auto-paste failed, leaving clipboard for manual paste:", err);
+    }
+  }
+
   private async finishRecording(child: ChildProcess, wavPath: string): Promise<void> {
     this.isTranscribing = true;
     try {
@@ -227,6 +243,11 @@ export class DictationService extends EventEmitter {
       debug("transcribed:", result.text.length, "chars, lang=", result.language);
       if (result.text.length > 0) {
         clipboard.writeText(result.text);
+        // Focus-aware paste (#90): if the user's cursor sits inside a text
+        // input, slip the transcript in via Cmd+V; otherwise leave it on the
+        // clipboard so they can place it deliberately. Both probe and paste
+        // are best-effort — failures swallow back to clipboard-only.
+        await this.maybeAutoPaste();
         this.emit("transcribed", result);
       } else {
         this.emit(

--- a/desktop/dictation/focus-paste.ts
+++ b/desktop/dictation/focus-paste.ts
@@ -1,0 +1,176 @@
+// desktop/dictation/focus-paste.ts
+//
+// After whisper transcription writes to the clipboard, we ask the OS whether
+// the user's current focus accepts text. If yes — slip the transcript in via
+// a synthetic Cmd+V. If no — leave it on the clipboard so the user can paste
+// it deliberately. See #90.
+//
+// Two collaborators live here so the dictation service only imports a single
+// module:
+//   - `probeFocusedElement()` spawns focus-probe (Swift, AX-based) and parses
+//     its JSON output.
+//   - `sendPasteKeystroke()` spawns the existing send-keystroke helper to
+//     synthesize Cmd+V — same Swift binary the translator's layout switcher
+//     uses.
+//
+// Both calls have aggressive timeouts (250 ms / 1.5 s) so a hung helper can
+// never block the dictation event loop.
+//
+// The parsing helper is exported separately for unit tests — we don't want to
+// spawn real Swift binaries in CI.
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { asarUnpacked } from "../utils/asar-paths.ts";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const dictationDistDir = asarUnpacked(path.dirname(currentFilePath));
+const translatorDistDir = asarUnpacked(
+  path.resolve(path.dirname(currentFilePath), "..", "translator")
+);
+
+const DEFAULT_PROBE_BIN = path.join(dictationDistDir, "focus-probe");
+const DEFAULT_SEND_KEY_BIN = path.join(translatorDistDir, "send-keystroke");
+const PROBE_TIMEOUT_MS = 250;
+const PASTE_TIMEOUT_MS = 1_500;
+
+export interface FocusProbeResult {
+  isTextInput: boolean;
+  role: string;
+  subrole: string;
+}
+
+const FALLBACK: FocusProbeResult = { isTextInput: false, role: "", subrole: "" };
+
+/**
+ * Parse the JSON line emitted by focus-probe. Tolerates whitespace, partial
+ * output, and malformed JSON — anything unexpected collapses to "no text
+ * input" so the safe default (clipboard-only) wins.
+ */
+export function parseFocusProbe(stdout: string): FocusProbeResult {
+  const trimmed = stdout.trim();
+  if (!trimmed) return FALLBACK;
+  try {
+    const obj: unknown = JSON.parse(trimmed);
+    if (typeof obj !== "object" || obj === null) return FALLBACK;
+    const record = obj as Record<string, unknown>;
+    return {
+      isTextInput: record.isTextInput === true,
+      role: typeof record.role === "string" ? record.role : "",
+      subrole: typeof record.subrole === "string" ? record.subrole : ""
+    };
+  } catch {
+    return FALLBACK;
+  }
+}
+
+export interface ProbeOptions {
+  binPath?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Spawn focus-probe and resolve with the parsed result. Never rejects — any
+ * spawn / timeout / parse failure resolves to FALLBACK so the dictation flow
+ * degrades gracefully to clipboard-only.
+ */
+export function probeFocusedElement(options: ProbeOptions = {}): Promise<FocusProbeResult> {
+  const binPath = options.binPath ?? DEFAULT_PROBE_BIN;
+  const timeoutMs = options.timeoutMs ?? PROBE_TIMEOUT_MS;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+    try {
+      child = spawn(binPath, [], { stdio: ["ignore", "pipe", "ignore"] });
+    } catch {
+      resolve(FALLBACK);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      resolve(FALLBACK);
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+
+    child.on("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(FALLBACK);
+    });
+
+    child.on("close", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(parseFocusProbe(stdout));
+    });
+  });
+}
+
+export interface PasteOptions {
+  binPath?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Spawn send-keystroke with `v` to synthesize Cmd+V into the frontmost app.
+ * Rejects on spawn / non-zero exit / timeout — the caller decides whether to
+ * surface or swallow the failure (dictation swallows: clipboard fallback
+ * remains usable).
+ */
+export function sendPasteKeystroke(options: PasteOptions = {}): Promise<void> {
+  const binPath = options.binPath ?? DEFAULT_SEND_KEY_BIN;
+  const timeoutMs = options.timeoutMs ?? PASTE_TIMEOUT_MS;
+
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(binPath, ["v"], { stdio: ["ignore", "ignore", "pipe"] });
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error(`send-keystroke timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`send-keystroke exited ${code}: ${stderr.slice(0, 200) || "(no stderr)"}`));
+      }
+    });
+  });
+}

--- a/desktop/dictation/focus-probe.swift
+++ b/desktop/dictation/focus-probe.swift
@@ -1,0 +1,105 @@
+// desktop/dictation/focus-probe.swift
+//
+// Probe the system-wide focused UI element via AXUIElement and report whether
+// it accepts text input. Used by dictation-service to decide between
+// clipboard-only (no focused field) and clipboard+paste (focused text field).
+//
+// Output: a single line of JSON on stdout, e.g.
+//   {"isTextInput":true,"role":"AXTextField","subrole":""}
+// Exit code is always 0 — failure is conveyed as isTextInput:false so the
+// caller never has to disambiguate "no focus" from "probe crashed".
+//
+// Requires macOS Accessibility permission (shared with uiohook-napi). Without
+// it AXUIElementCopyAttributeValue returns kAXErrorAPIDisabled and we report
+// isTextInput:false, which preserves clipboard-only behavior.
+
+import ApplicationServices
+import Foundation
+
+struct ProbeResult {
+    let isTextInput: Bool
+    let role: String
+    let subrole: String
+}
+
+func copyString(_ element: AXUIElement, _ attribute: String) -> String {
+    var ref: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(element, attribute as CFString, &ref)
+    guard err == .success else { return "" }
+    return (ref as? String) ?? ""
+}
+
+func isSettable(_ element: AXUIElement, _ attribute: String) -> Bool {
+    var settable: DarwinBoolean = false
+    let err = AXUIElementIsAttributeSettable(element, attribute as CFString, &settable)
+    return err == .success && settable.boolValue
+}
+
+func probe() -> ProbeResult {
+    let system = AXUIElementCreateSystemWide()
+    var focusedRef: CFTypeRef?
+    let err = AXUIElementCopyAttributeValue(
+        system, kAXFocusedUIElementAttribute as CFString, &focusedRef
+    )
+    guard err == .success, let focusedRef = focusedRef else {
+        return ProbeResult(isTextInput: false, role: "", subrole: "")
+    }
+
+    let element = focusedRef as! AXUIElement
+    let role = copyString(element, kAXRoleAttribute as String)
+    let subrole = copyString(element, kAXSubroleAttribute as String)
+
+    // Strong, unambiguous text-input roles. Covers native AppKit text fields,
+    // multi-line text views, search bars, and combo boxes' text portion.
+    let textRoles: Set<String> = [
+        "AXTextField",
+        "AXTextArea",
+        "AXComboBox",
+        "AXSearchField"
+    ]
+    if textRoles.contains(role) {
+        return ProbeResult(isTextInput: true, role: role, subrole: subrole)
+    }
+
+    // Fallback for web / Electron renderers: contenteditable elements often
+    // surface as generic AXGroup / AXScrollArea but still mark AXValue as
+    // settable. Querying settability is the canonical AX way to ask
+    // "can I type into this?" without exhaustively enumerating Chromium's
+    // role mapping.
+    if isSettable(element, kAXValueAttribute as String) {
+        return ProbeResult(isTextInput: true, role: role, subrole: subrole)
+    }
+
+    return ProbeResult(isTextInput: false, role: role, subrole: subrole)
+}
+
+func escape(_ value: String) -> String {
+    // Minimal JSON string escaping — role/subrole are AX constants like
+    // "AXTextField"; backslashes and quotes never occur in practice but we
+    // handle them anyway so a malformed third-party app can't break the JSON.
+    var out = ""
+    out.reserveCapacity(value.count)
+    for ch in value {
+        switch ch {
+        case "\"": out += "\\\""
+        case "\\": out += "\\\\"
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case "\t": out += "\\t"
+        default:
+            if ch.asciiValue.map({ $0 < 0x20 }) ?? false {
+                out += String(format: "\\u%04x", Int(ch.asciiValue ?? 0))
+            } else {
+                out.append(ch)
+            }
+        }
+    }
+    return out
+}
+
+let result = probe()
+let json = "{\"isTextInput\":\(result.isTextInput ? "true" : "false")," +
+    "\"role\":\"\(escape(result.role))\"," +
+    "\"subrole\":\"\(escape(result.subrole))\"}"
+print(json)
+exit(0)

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -102,6 +102,12 @@ if (process.platform === "darwin") {
       fallbackNote: "voice dictation will be disabled"
     },
     {
+      src: path.join(root, "desktop", "dictation", "focus-probe.swift"),
+      out: path.join(root, "dist", "desktop", "dictation", "focus-probe"),
+      label: "focus-probe",
+      fallbackNote: "dictation will fall back to clipboard-only (no auto-paste)"
+    },
+    {
       src: path.join(root, "desktop", "translator", "apple-vision-ocr.swift"),
       out: path.join(root, "dist", "desktop", "translator", "apple-vision-ocr"),
       label: "apple-vision-ocr",

--- a/tests/focus-paste.test.ts
+++ b/tests/focus-paste.test.ts
@@ -1,0 +1,175 @@
+// tests/focus-paste.test.ts
+// Unit tests for the pure helpers in focus-paste.ts. The spawn-based bridges
+// to Swift binaries are exercised through the optional `binPath` override so
+// no real macOS AX traffic happens here.
+
+import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtemp, writeFile, chmod, rm } from "node:fs/promises";
+import os from "node:os";
+
+import {
+  parseFocusProbe,
+  probeFocusedElement,
+  sendPasteKeystroke
+} from "../desktop/dictation/focus-paste.ts";
+
+void spawn;
+
+const __filename = fileURLToPath(import.meta.url);
+const tmpRoot = path.join(os.tmpdir(), "marshal-focus-paste-tests");
+
+async function writeStubBin(name: string, body: string): Promise<string> {
+  const dir = await mkdtemp(`${tmpRoot}-`);
+  const target = path.join(dir, name);
+  await writeFile(target, `#!/usr/bin/env bash\n${body}\n`);
+  await chmod(target, 0o755);
+  return target;
+}
+
+void __filename;
+
+describe("parseFocusProbe", () => {
+  it("parses a well-formed JSON response", () => {
+    const result = parseFocusProbe('{"isTextInput":true,"role":"AXTextField","subrole":""}');
+    expect(result).toEqual({ isTextInput: true, role: "AXTextField", subrole: "" });
+  });
+
+  it("trims surrounding whitespace and newlines", () => {
+    const result = parseFocusProbe('   {"isTextInput":false,"role":"AXButton","subrole":""}\n');
+    expect(result.isTextInput).toBe(false);
+    expect(result.role).toBe("AXButton");
+  });
+
+  it("falls back to safe defaults on empty input", () => {
+    expect(parseFocusProbe("")).toEqual({ isTextInput: false, role: "", subrole: "" });
+    expect(parseFocusProbe("   ")).toEqual({ isTextInput: false, role: "", subrole: "" });
+  });
+
+  it("falls back when JSON is malformed", () => {
+    expect(parseFocusProbe("not json at all")).toEqual({
+      isTextInput: false,
+      role: "",
+      subrole: ""
+    });
+    expect(parseFocusProbe('{"isTextInput":true')).toEqual({
+      isTextInput: false,
+      role: "",
+      subrole: ""
+    });
+  });
+
+  it("treats non-boolean isTextInput as false (strict equality)", () => {
+    expect(parseFocusProbe('{"isTextInput":"true","role":"X"}').isTextInput).toBe(false);
+    expect(parseFocusProbe('{"isTextInput":1,"role":"X"}').isTextInput).toBe(false);
+  });
+
+  it("coerces missing string fields to empty strings", () => {
+    const result = parseFocusProbe('{"isTextInput":true}');
+    expect(result).toEqual({ isTextInput: true, role: "", subrole: "" });
+  });
+
+  it("rejects non-object top-level values", () => {
+    expect(parseFocusProbe("null")).toEqual({ isTextInput: false, role: "", subrole: "" });
+    expect(parseFocusProbe('"AXTextField"')).toEqual({
+      isTextInput: false,
+      role: "",
+      subrole: ""
+    });
+    expect(parseFocusProbe("[true, true]")).toEqual({
+      isTextInput: false,
+      role: "",
+      subrole: ""
+    });
+  });
+});
+
+describe("probeFocusedElement", () => {
+  it("returns parsed JSON when the helper exits cleanly", async () => {
+    const bin = await writeStubBin(
+      "focus-probe-success",
+      'echo \'{"isTextInput":true,"role":"AXTextField","subrole":""}\''
+    );
+    try {
+      const result = await probeFocusedElement({ binPath: bin });
+      expect(result).toEqual({ isTextInput: true, role: "AXTextField", subrole: "" });
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+
+  it("resolves to clipboard-only fallback if the binary is missing", async () => {
+    const result = await probeFocusedElement({
+      binPath: "/nonexistent/path/focus-probe-does-not-exist"
+    });
+    expect(result).toEqual({ isTextInput: false, role: "", subrole: "" });
+  });
+
+  it("times out gracefully when the helper hangs", async () => {
+    const bin = await writeStubBin("focus-probe-hang", "sleep 5");
+    try {
+      const start = Date.now();
+      const result = await probeFocusedElement({ binPath: bin, timeoutMs: 100 });
+      const elapsed = Date.now() - start;
+      expect(result.isTextInput).toBe(false);
+      // Generous upper bound — the timer fires at ~100 ms; SIGKILL + close
+      // event have some slack on slow CI but should be well under 2 s.
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+
+  it("falls back on malformed helper output", async () => {
+    const bin = await writeStubBin("focus-probe-garbage", 'echo "not a json"');
+    try {
+      const result = await probeFocusedElement({ binPath: bin });
+      expect(result).toEqual({ isTextInput: false, role: "", subrole: "" });
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+});
+
+describe("sendPasteKeystroke", () => {
+  it("resolves on exit 0", async () => {
+    const bin = await writeStubBin("send-keystroke-ok", "exit 0");
+    try {
+      await expect(sendPasteKeystroke({ binPath: bin })).resolves.toBeUndefined();
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+
+  it("rejects with stderr in the message on non-zero exit", async () => {
+    const bin = await writeStubBin(
+      "send-keystroke-fail",
+      'echo "no accessibility" >&2; exit 7'
+    );
+    try {
+      await expect(sendPasteKeystroke({ binPath: bin })).rejects.toThrow(/exited 7/);
+      await expect(sendPasteKeystroke({ binPath: bin })).rejects.toThrow(/no accessibility/);
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+
+  it("rejects if the binary is missing", async () => {
+    await expect(
+      sendPasteKeystroke({ binPath: "/nonexistent/send-keystroke" })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("rejects via timeout when the helper hangs", async () => {
+    const bin = await writeStubBin("send-keystroke-hang", "sleep 5");
+    try {
+      await expect(
+        sendPasteKeystroke({ binPath: bin, timeoutMs: 80 })
+      ).rejects.toThrow(/timed out/);
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

After whisper transcription:
- **Text input focused** (AXTextField / AXTextArea / contenteditable webarea / search field) → text written to clipboard **and** Cmd+V'd into place.
- **No text input focused** → clipboard-only, no paste — so we never mangle a Finder selection, Spotlight, or whatever else.

New Swift helper `focus-probe` uses `AXUIElementCreateSystemWide` + `kAXFocusedUIElementAttribute` to inspect role / settability. New TS wrapper `focus-paste.ts` spawns it with a 250 ms timeout, parses JSON, and delegates Cmd+V to the existing `send-keystroke` helper.

## Decision rule (focus-probe.swift)

1. Strong signal — focused element role is one of `AXTextField`, `AXTextArea`, `AXComboBox`, `AXSearchField` → treat as text input.
2. Fallback — `AXUIElementIsAttributeSettable(element, kAXValueAttribute)`. Catches Chromium / Electron contenteditable that report generic `AXGroup` / `AXScrollArea` roles but still accept value writes.
3. Anything else → clipboard-only.

## Robustness

Every step is best-effort and degrades to current behavior (clipboard-only) on any failure:
- Probe spawn fails → fallback returned, no paste.
- Probe hangs → SIGKILL at 250 ms, fallback returned.
- Probe emits malformed JSON → parsed as `isTextInput: false`.
- `send-keystroke v` non-zero exit → swallowed in debug log, transcript still on clipboard.

15 new vitest cases cover all of these paths via stub bash binaries (no real Swift / AX traffic in CI).

## Verification

- `npm run check` → 227 tests pass (was 212), typecheck clean
- `dist/desktop/dictation/focus-probe` runs standalone, emits valid JSON
- Codesigned with `Marshal Self-Signed`, stable CDHash `c6566343…` (leverages #88 infrastructure)

## Test plan

- [ ] Stand in Claude Code prompt → Cmd+Alt+M → speak → release → text appears inline at cursor
- [ ] Stand in Slack composer / Notes / VS Code editor / browser URL bar → text appears inline
- [ ] Cmd+Tab to Finder, stand on a file row (no editable focus) → speak → text only in clipboard, Finder unchanged
- [ ] Open Spotlight (Cmd+Space) with no field focused → speak → clipboard-only, no garbage typed into Spotlight
- [ ] `MARSHAL_DICTATION_DEBUG=1 npm run desktop` → debug log shows `auto-pasting (role=AXTextArea)` for inputs and `no editable focus — clipboard only` otherwise

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)