### PR TITLE
feat(dictation): user-selectable microphone (#95)

### DIFF
--- a/desktop/dictation/audio-recorder.swift
+++ b/desktop/dictation/audio-recorder.swift
@@ -9,28 +9,57 @@
 // writes a proper WAV header on stop(). Previous AVAudioEngine implementation
 // crashed with -10868 (AUGraphParser) on AirPods. See #52, #53.
 //
+// Device selection (#95): AVAudioRecorder always records from the system
+// default input. To let the user pick a different mic without bouncing
+// through System Settings, we optionally swap the default input on launch
+// and restore it on shutdown. The swap is per-system, so it's racy in
+// theory (another app starting input capture during our recording would
+// also flip to our pick) but single-tenant input is the macOS norm.
+//
 // Lifecycle:
-//   - start recording immediately on launch
-//   - prints "ready" to stdout when the recorder is armed (Node uses this as
-//     a signal that it's safe to treat the process as recording)
-//   - stops on SIGTERM / SIGINT, flushes the WAV file, then exits 0
+//   - parse args
+//   - swap default input device if --device specified
+//   - start recording immediately
+//   - prints "ready" to stdout when armed (Node uses this as a signal that
+//     it's safe to treat the process as recording)
+//   - on SIGTERM / SIGINT: stop, flush WAV, restore previous default, exit 0
 //
 // Usage:
-//   audio-recorder /tmp/marshal-dict-<uuid>.wav
+//   audio-recorder <out.wav>
+//   audio-recorder <out.wav> --device <coreaudio-uniqueID>
 
 import Foundation
 import AVFoundation
+import CoreAudio
+
+// ── arg parsing ──
 
 let args = CommandLine.arguments
 guard args.count >= 2 else {
-    FileHandle.standardError.write("usage: audio-recorder <out.wav>\n".data(using: .utf8)!)
+    FileHandle.standardError.write(
+        "usage: audio-recorder <out.wav> [--device <uniqueID>]\n".data(using: .utf8)!
+    )
     exit(2)
 }
 let outPath = args[1]
 let outURL = URL(fileURLWithPath: outPath)
 
-// macOS 10.14+ requires explicit microphone permission. Without it the
-// recorder silently captures zeros — surface the failure as exit(6) instead.
+var requestedDeviceUID: String? = nil
+var i = 2
+while i < args.count {
+    let arg = args[i]
+    if arg == "--device" && i + 1 < args.count {
+        let raw = args[i + 1].trimmingCharacters(in: .whitespacesAndNewlines)
+        if !raw.isEmpty { requestedDeviceUID = raw }
+        i += 2
+        continue
+    }
+    FileHandle.standardError.write("ignoring unknown arg: \(arg)\n".data(using: .utf8)!)
+    i += 1
+}
+
+// ── microphone permission ──
+
 func ensureMicrophonePermission() {
     let status = AVCaptureDevice.authorizationStatus(for: .audio)
     switch status {
@@ -61,6 +90,105 @@ func ensureMicrophonePermission() {
 
 ensureMicrophonePermission()
 
+// ── HAL helpers for device swap ──
+
+func readDefaultInputDevice() -> AudioDeviceID? {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultInputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var deviceID: AudioDeviceID = 0
+    var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+    let err = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &deviceID
+    )
+    return err == noErr ? deviceID : nil
+}
+
+func setDefaultInputDevice(_ deviceID: AudioDeviceID) -> Bool {
+    var deviceID = deviceID
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultInputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    let err = AudioObjectSetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil,
+        UInt32(MemoryLayout<AudioDeviceID>.size), &deviceID
+    )
+    return err == noErr
+}
+
+func findDeviceByUID(_ uid: String) -> AudioDeviceID? {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDevices,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var dataSize: UInt32 = 0
+    var err = AudioObjectGetPropertyDataSize(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize
+    )
+    guard err == noErr else { return nil }
+    let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+    if count == 0 { return nil }
+    var ids = [AudioDeviceID](repeating: 0, count: count)
+    err = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &ids
+    )
+    guard err == noErr else { return nil }
+
+    for deviceID in ids {
+        var uidAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var cfString: Unmanaged<CFString>?
+        var uidSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let uidErr = AudioObjectGetPropertyData(
+            deviceID, &uidAddress, 0, nil, &uidSize, &cfString
+        )
+        if uidErr == noErr, let unmanaged = cfString {
+            if (unmanaged.takeRetainedValue() as String) == uid { return deviceID }
+        }
+    }
+    return nil
+}
+
+// ── device swap (best-effort) ──
+
+let previousDefaultInput: AudioDeviceID? = readDefaultInputDevice()
+var swappedInput = false
+
+if let uid = requestedDeviceUID {
+    if let deviceID = findDeviceByUID(uid) {
+        if deviceID != previousDefaultInput {
+            if setDefaultInputDevice(deviceID) {
+                swappedInput = true
+            } else {
+                FileHandle.standardError.write(
+                    "failed to set default input to \(uid); proceeding with system default\n".data(using: .utf8)!
+                )
+            }
+        }
+        // else: already the default — nothing to do.
+    } else {
+        FileHandle.standardError.write(
+            "requested device \(uid) not present; proceeding with system default\n".data(using: .utf8)!
+        )
+    }
+}
+
+func restoreDefaultInput() {
+    if swappedInput, let original = previousDefaultInput {
+        _ = setDefaultInputDevice(original)
+    }
+}
+
+// ── recorder setup ──
+
 // whisper.cpp expects 16 kHz mono 16-bit PCM WAV. AVAudioRecorder resamples
 // from whatever the input device natively produces — AirPods 24 kHz, built-in
 // 48 kHz, USB mics 44.1 kHz, all end up in this one format.
@@ -77,11 +205,13 @@ var recorder: AVAudioRecorder
 do {
     recorder = try AVAudioRecorder(url: outURL, settings: settings)
 } catch {
+    restoreDefaultInput()
     FileHandle.standardError.write("AVAudioRecorder init failed: \(error)\n".data(using: .utf8)!)
     exit(4)
 }
 
 guard recorder.prepareToRecord() else {
+    restoreDefaultInput()
     FileHandle.standardError.write(
         "prepareToRecord() returned false. Check System Settings → Sound → Input — the default device may be unavailable.\n".data(using: .utf8)!
     )
@@ -89,6 +219,7 @@ guard recorder.prepareToRecord() else {
 }
 
 guard recorder.record() else {
+    restoreDefaultInput()
     FileHandle.standardError.write(
         "record() returned false. Verify that an input device is connected and selected in System Settings → Sound → Input.\n".data(using: .utf8)!
     )
@@ -99,6 +230,7 @@ func shutdown() -> Never {
     // stop() flushes the WAV header and closes the file synchronously. Safe
     // to call from a DispatchSource signal handler on the main queue.
     recorder.stop()
+    restoreDefaultInput()
     exit(0)
 }
 

--- a/desktop/dictation/dictation-service.ts
+++ b/desktop/dictation/dictation-service.ts
@@ -125,9 +125,14 @@ export class DictationService extends EventEmitter {
 
     const wavPath = path.join(os.tmpdir(), `marshal-dict-${randomUUID()}.wav`);
     this.currentWavPath = wavPath;
-    debug("  spawn recorder:", this.recorderBin, "→", wavPath);
+    // Microphone selection (#95): if MARSHAL_DICTATION_MIC is set, pass it
+    // to audio-recorder as `--device <uniqueID>`. Empty / unset → recorder
+    // uses the system default input, same behavior as before.
+    const micUid = (process.env.MARSHAL_DICTATION_MIC ?? "").trim();
+    const recorderArgs = micUid ? [wavPath, "--device", micUid] : [wavPath];
+    debug("  spawn recorder:", this.recorderBin, "→", wavPath, micUid ? `(mic=${micUid})` : "");
 
-    const child = spawn(this.recorderBin, [wavPath], { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(this.recorderBin, recorderArgs, { stdio: ["ignore", "pipe", "pipe"] });
     this.recorderProcess = child;
     this.isStopping = false;
 

--- a/desktop/dictation/mic-discover.ts
+++ b/desktop/dictation/mic-discover.ts
@@ -1,0 +1,106 @@
+// desktop/dictation/mic-discover.ts
+//
+// Spawn the Core Audio mic-list helper and parse its JSON output for the
+// settings dropdown. Pure I/O wrapper — no UI side-effects, no caching.
+// Cached at the renderer layer; if the user plugs in a new device the
+// settings panel re-invokes this to refresh.
+//
+// Failure modes (all degrade to an empty list rather than throwing):
+//   - binary missing (postbuild skipped on a non-darwin machine)
+//   - hang (250 ms timeout, SIGKILL)
+//   - non-zero exit (HAL refused — we still try to parse stdout, then bail)
+//   - malformed JSON
+//
+// Result is a flat list; the caller prepends a "System default" entry.
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { asarUnpacked } from "../utils/asar-paths.ts";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const dictationDistDir = asarUnpacked(path.dirname(currentFilePath));
+const DEFAULT_MIC_LIST_BIN = path.join(dictationDistDir, "mic-list");
+const MIC_LIST_TIMEOUT_MS = 1_500;
+
+export interface Microphone {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  manufacturer: string;
+  transportType: string;
+}
+
+export function parseMicList(stdout: string): Microphone[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+  try {
+    const obj: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(obj)) return [];
+    const out: Microphone[] = [];
+    for (const entry of obj) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const rec = entry as Record<string, unknown>;
+      const id = typeof rec.id === "string" ? rec.id : "";
+      if (!id) continue;
+      out.push({
+        id,
+        name: typeof rec.name === "string" && rec.name.length > 0 ? rec.name : id,
+        isDefault: rec.isDefault === true,
+        manufacturer: typeof rec.manufacturer === "string" ? rec.manufacturer : "",
+        transportType: typeof rec.transportType === "string" ? rec.transportType : ""
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+export interface ListMicrophonesOptions {
+  binPath?: string;
+  timeoutMs?: number;
+}
+
+export function listMicrophones(options: ListMicrophonesOptions = {}): Promise<Microphone[]> {
+  const binPath = options.binPath ?? DEFAULT_MIC_LIST_BIN;
+  const timeoutMs = options.timeoutMs ?? MIC_LIST_TIMEOUT_MS;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let stdout = "";
+    let child;
+    try {
+      child = spawn(binPath, [], { stdio: ["ignore", "pipe", "ignore"] });
+    } catch {
+      resolve([]);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      resolve([]);
+    }, timeoutMs);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+
+    child.on("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve([]);
+    });
+
+    child.on("close", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(parseMicList(stdout));
+    });
+  });
+}

--- a/desktop/dictation/mic-list.swift
+++ b/desktop/dictation/mic-list.swift
@@ -1,0 +1,201 @@
+// desktop/dictation/mic-list.swift
+//
+// Enumerate macOS audio input devices via Core Audio HAL and emit a JSON
+// array on stdout. Read by the settings UI to populate the Microphone
+// dropdown so the user can pick which device dictation records from.
+//
+// Output (single line on stdout):
+//   [{"id":"AppleHDAEngineInput:1F,3,0,1,0:1","name":"MacBook Pro Microphone",
+//     "isDefault":true,"manufacturer":"Apple Inc.","transportType":"BuiltIn"},
+//    {"id":"...", "name":"AirPods Pro", "isDefault":false, ...}]
+//
+// Exit 0 always — on any HAL failure emits `[]` and `[hal] ...` lines on
+// stderr. Callers should never block on this — it's a dropdown, not the
+// recording path.
+//
+// No microphone permission required: enumerating device IDs / names is a
+// metadata query, not capture. The actual audio-recorder.swift handles TCC.
+
+import Foundation
+import CoreAudio
+
+// ── HAL primitives ──
+
+func readDeviceList() -> [AudioDeviceID] {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDevices,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var dataSize: UInt32 = 0
+    var err = AudioObjectGetPropertyDataSize(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize
+    )
+    guard err == noErr else {
+        FileHandle.standardError.write("[hal] device list size: \(err)\n".data(using: .utf8)!)
+        return []
+    }
+    let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+    if count == 0 { return [] }
+    var ids = [AudioDeviceID](repeating: 0, count: count)
+    err = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &ids
+    )
+    guard err == noErr else {
+        FileHandle.standardError.write("[hal] device list read: \(err)\n".data(using: .utf8)!)
+        return []
+    }
+    return ids
+}
+
+func readDefaultInputDevice() -> AudioDeviceID? {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioHardwarePropertyDefaultInputDevice,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var deviceID: AudioDeviceID = 0
+    var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+    let err = AudioObjectGetPropertyData(
+        AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &dataSize, &deviceID
+    )
+    return err == noErr ? deviceID : nil
+}
+
+func hasInputStreams(_ device: AudioDeviceID) -> Bool {
+    var address = AudioObjectPropertyAddress(
+        mSelector: kAudioDevicePropertyStreams,
+        mScope: kAudioObjectPropertyScopeInput,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var dataSize: UInt32 = 0
+    let err = AudioObjectGetPropertyDataSize(device, &address, 0, nil, &dataSize)
+    if err != noErr { return false }
+    return dataSize > 0
+}
+
+func readStringProperty(_ device: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> String? {
+    var address = AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    // CoreAudio returns a +1 retained CFString here, so we use Unmanaged to
+    // make ownership explicit and balance it with takeRetainedValue. Avoids
+    // the Swift 6 overlapping-access trap from passing &cfString through a
+    // nested pointer-rebind.
+    var cfString: Unmanaged<CFString>?
+    var dataSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+    let err = AudioObjectGetPropertyData(device, &address, 0, nil, &dataSize, &cfString)
+    if err != noErr { return nil }
+    guard let unmanaged = cfString else { return nil }
+    return unmanaged.takeRetainedValue() as String
+}
+
+func readUInt32Property(_ device: AudioDeviceID, _ selector: AudioObjectPropertySelector) -> UInt32? {
+    var address = AudioObjectPropertyAddress(
+        mSelector: selector,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain
+    )
+    var value: UInt32 = 0
+    var dataSize = UInt32(MemoryLayout<UInt32>.size)
+    let err = AudioObjectGetPropertyData(device, &address, 0, nil, &dataSize, &value)
+    return err == noErr ? value : nil
+}
+
+func transportTypeName(_ raw: UInt32?) -> String {
+    guard let raw = raw else { return "Unknown" }
+    switch raw {
+    case kAudioDeviceTransportTypeBuiltIn: return "BuiltIn"
+    case kAudioDeviceTransportTypeAggregate: return "Aggregate"
+    case kAudioDeviceTransportTypeVirtual: return "Virtual"
+    case kAudioDeviceTransportTypePCI: return "PCI"
+    case kAudioDeviceTransportTypeUSB: return "USB"
+    case kAudioDeviceTransportTypeFireWire: return "FireWire"
+    case kAudioDeviceTransportTypeBluetooth: return "Bluetooth"
+    case kAudioDeviceTransportTypeBluetoothLE: return "BluetoothLE"
+    case kAudioDeviceTransportTypeHDMI: return "HDMI"
+    case kAudioDeviceTransportTypeDisplayPort: return "DisplayPort"
+    case kAudioDeviceTransportTypeAirPlay: return "AirPlay"
+    case kAudioDeviceTransportTypeAVB: return "AVB"
+    case kAudioDeviceTransportTypeThunderbolt: return "Thunderbolt"
+    case kAudioDeviceTransportTypeContinuityCaptureWired: return "Continuity"
+    case kAudioDeviceTransportTypeContinuityCaptureWireless: return "ContinuityWireless"
+    default: return "Unknown"
+    }
+}
+
+// ── JSON escaping ──
+
+func jsonString(_ value: String) -> String {
+    var out = "\""
+    out.reserveCapacity(value.count + 2)
+    for ch in value {
+        switch ch {
+        case "\"": out += "\\\""
+        case "\\": out += "\\\\"
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case "\t": out += "\\t"
+        default:
+            if let ascii = ch.asciiValue, ascii < 0x20 {
+                out += String(format: "\\u%04x", Int(ascii))
+            } else {
+                out.append(ch)
+            }
+        }
+    }
+    out += "\""
+    return out
+}
+
+// ── Main ──
+
+let defaultDevice = readDefaultInputDevice()
+let allDevices = readDeviceList()
+
+struct MicEntry {
+    let id: String
+    let name: String
+    let manufacturer: String
+    let transportType: String
+    let isDefault: Bool
+}
+
+var entries: [MicEntry] = []
+for deviceID in allDevices {
+    guard hasInputStreams(deviceID) else { continue }
+    let uid = readStringProperty(deviceID, kAudioDevicePropertyDeviceUID) ?? ""
+    let name = readStringProperty(deviceID, kAudioObjectPropertyName)
+        ?? readStringProperty(deviceID, kAudioDevicePropertyDeviceNameCFString)
+        ?? "(unnamed input \(deviceID))"
+    let manufacturer = readStringProperty(deviceID, kAudioDevicePropertyDeviceManufacturerCFString) ?? ""
+    let transport = transportTypeName(readUInt32Property(deviceID, kAudioDevicePropertyTransportType))
+    let isDefault = (defaultDevice != nil) && (defaultDevice == deviceID)
+    if uid.isEmpty { continue }   // can't be addressed by uniqueID — skip
+    entries.append(MicEntry(
+        id: uid, name: name, manufacturer: manufacturer,
+        transportType: transport, isDefault: isDefault
+    ))
+}
+
+// Stable order: default first, then by name. Makes the dropdown predictable
+// for users and tests.
+entries.sort { lhs, rhs in
+    if lhs.isDefault != rhs.isDefault { return lhs.isDefault }
+    return lhs.name.localizedCompare(rhs.name) == .orderedAscending
+}
+
+var json = "["
+for (idx, entry) in entries.enumerated() {
+    if idx > 0 { json += "," }
+    json += "{\"id\":\(jsonString(entry.id))," +
+        "\"name\":\(jsonString(entry.name))," +
+        "\"isDefault\":\(entry.isDefault ? "true" : "false")," +
+        "\"manufacturer\":\(jsonString(entry.manufacturer))," +
+        "\"transportType\":\(jsonString(entry.transportType))}"
+}
+json += "]"
+print(json)
+exit(0)

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -22,6 +22,7 @@ import { VideoRecorder } from "./capture/video-recorder.ts";
 import { GifDialog } from "./capture/gif-dialog.ts";
 import { GifEncoder } from "./capture/gif-encoder.ts";
 import { DictationService } from "./dictation/dictation-service.ts";
+import { listMicrophones } from "./dictation/mic-discover.ts";
 import { DEFAULT_DICTATION_PROMPT } from "./dictation/whisper-backend.ts";
 import { applySettingsToEnv, loadSettings, saveSettings, type MarshalSettings } from "./settings-store.ts";
 import { ClipboardMonitor } from "./translator/clipboard-monitor.ts";
@@ -239,6 +240,15 @@ function registerIpcHandlers(): void {
     return { ok: true };
   });
   handleIpc("marshal:get-dictation-defaults", () => ({ prompt: DEFAULT_DICTATION_PROMPT }));
+  handleIpc("marshal:dictation-list-mics", async () => {
+    try {
+      const devices = await listMicrophones();
+      return { ok: true, devices };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, devices: [], error: message };
+    }
+  });
   handleIpc("marshal:update-settings", async (_event, next: Partial<MarshalSettings>) => {
     const saved = saveSettings(next ?? {});
     applySettingsToEnv(saved);

--- a/desktop/preload.cts
+++ b/desktop/preload.cts
@@ -107,8 +107,14 @@ const desktopApi = {
     dictationLanguage?: string;
     dictationAutoPaste?: boolean;
     dictationPrompt?: string;
+    dictationMicrophone?: string;
   }) => ipcRenderer.invoke("marshal:update-settings", settings),
   getDictationDefaults: () => ipcRenderer.invoke("marshal:get-dictation-defaults") as Promise<{ prompt: string }>,
+  listMicrophones: () => ipcRenderer.invoke("marshal:dictation-list-mics") as Promise<{
+    ok: boolean;
+    devices: Array<{ id: string; name: string; isDefault: boolean; manufacturer: string; transportType: string }>;
+    error?: string;
+  }>,
   checkForUpdatesSilent: () => ipcRenderer.invoke("marshal:check-for-updates-silent") as Promise<
     | { available: false; error: string }
     | {

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -10,6 +10,44 @@ const STORAGE_KEYS = {
 const MAX_RECENT_DIRS = 5;
 const APPEARANCE_VALUES = ["light", "dark", "system"];
 
+async function populateMicrophoneDropdown(preferredValue) {
+  // Re-build the input-device dropdown from a fresh listMicrophones() call.
+  // The default "System default" option is the first <option> in the markup
+  // and is preserved across rebuilds — its value is the empty string, which
+  // is also what settings save as "track macOS default". See #95.
+  const select = dom.settingsDictationMicrophone;
+  if (!select || !api?.listMicrophones) return;
+  let result;
+  try {
+    result = await api.listMicrophones();
+  } catch (err) {
+    console.warn("listMicrophones failed", err);
+    return;
+  }
+  const devices = Array.isArray(result?.devices) ? result.devices : [];
+  // Keep the first option (system default) and rebuild the rest.
+  const firstOption = select.firstElementChild;
+  select.innerHTML = "";
+  if (firstOption) select.appendChild(firstOption);
+  for (const device of devices) {
+    if (!device || typeof device.id !== "string" || !device.id) continue;
+    const option = document.createElement("option");
+    option.value = device.id;
+    const transport = device.transportType && device.transportType !== "Unknown"
+      ? ` · ${device.transportType}`
+      : "";
+    const defaultBadge = device.isDefault ? " (system default)" : "";
+    option.textContent = `${device.name}${transport}${defaultBadge}`;
+    select.appendChild(option);
+  }
+  // Re-apply the preferred selection. If the saved mic was unplugged (not in
+  // the new device list), browsers silently fall back to the first option,
+  // which is the "system default" sentinel — exactly the safe behavior.
+  if (typeof preferredValue === "string") {
+    select.value = preferredValue;
+  }
+}
+
 function loadAppearance() {
   const stored = localStorage.getItem(STORAGE_KEYS.appearance);
   if (APPEARANCE_VALUES.includes(stored)) return stored;
@@ -70,6 +108,8 @@ const dom = {
   settingsDictationAutoPaste: document.getElementById("settings-dictation-autopaste"),
   settingsDictationPrompt: document.getElementById("settings-dictation-prompt"),
   settingsDictationPromptReset: document.getElementById("settings-dictation-prompt-reset"),
+  settingsDictationMicrophone: document.getElementById("settings-dictation-microphone"),
+  settingsDictationMicrophoneRefresh: document.getElementById("settings-dictation-microphone-refresh"),
   settingsCaptureFolder: document.getElementById("settings-capture-folder"),
   settingsCaptureFolderPick: document.getElementById("settings-capture-folder-pick"),
   settingsLaunchAtLogin: document.getElementById("settings-launch-at-login"),
@@ -821,6 +861,14 @@ function bindEvents() {
       console.error("getDictationDefaults failed", err);
     }
   });
+  dom.settingsDictationMicrophoneRefresh?.addEventListener("click", async (e) => {
+    e.preventDefault();
+    // Preserve the user's current pick across a refresh — the device list may
+    // include / exclude their chosen mic depending on whether it's plugged in,
+    // but the value still needs to round-trip if we re-render the dropdown.
+    const previous = dom.settingsDictationMicrophone?.value ?? "";
+    await populateMicrophoneDropdown(previous);
+  });
   dom.settingsCheckUpdatesNow?.addEventListener("click", checkForUpdatesFromSettings);
   document.querySelectorAll('[data-close="settings"]').forEach((el) =>
     el.addEventListener("click", closeSettings)
@@ -919,6 +967,13 @@ async function openSettings() {
     if (dom.settingsDictationPrompt) {
       dom.settingsDictationPrompt.value = current.dictationPrompt ?? "";
     }
+    // Microphone dropdown is populated lazily — we fire-and-forget so the
+    // settings modal opens instantly even if HAL is slow. The default
+    // option ("") is already in the markup so the value sticks immediately.
+    if (dom.settingsDictationMicrophone) {
+      dom.settingsDictationMicrophone.value = current.dictationMicrophone ?? "";
+      void populateMicrophoneDropdown(current.dictationMicrophone ?? "");
+    }
     if (dom.settingsCaptureFolder) {
       dom.settingsCaptureFolder.value = current.captureDefaultFolder ?? "";
     }
@@ -972,6 +1027,7 @@ async function saveSettingsFromForm() {
     dictationHotkey: (dom.settingsDictationHotkey?.value ?? "RightCmd").trim() || "RightCmd",
     dictationBackend: dom.settingsDictationBackend?.value ?? "hybrid",
     dictationLanguage: dom.settingsDictationLanguage?.value ?? "auto",
+    dictationMicrophone: (dom.settingsDictationMicrophone?.value ?? "").trim(),
     dictationAutoPaste: dom.settingsDictationAutoPaste?.checked ?? false,
     dictationPrompt: dom.settingsDictationPrompt?.value ?? "",
     captureDefaultFolder: dom.settingsCaptureFolder?.value.trim() ?? "",

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -179,6 +179,19 @@
             </div>
 
             <div class="field">
+              <label for="settings-dictation-microphone">Microphone</label>
+              <select id="settings-dictation-microphone" name="dictationMicrophone">
+                <option value="">System default (track macOS Sound &gt; Input)</option>
+              </select>
+              <p class="field-hint">
+                Picks the input device for the next recording. While dictation is active Marshal
+                temporarily sets this as the system default input and restores it on release.
+                <a href="#" id="settings-dictation-microphone-refresh">Refresh list</a> after plugging
+                in a new mic.
+              </p>
+            </div>
+
+            <div class="field">
               <label for="settings-dictation-language">Spoken language</label>
               <select id="settings-dictation-language" name="dictationLanguage">
                 <option value="auto">Auto-detect (default)</option>

--- a/desktop/settings-store.ts
+++ b/desktop/settings-store.ts
@@ -46,6 +46,14 @@ export type MarshalSettings = {
    */
   dictationPrompt: string;
   /**
+   * Core Audio unique device ID of the microphone dictation records from.
+   * Empty string ("") means "track the system default" — same behavior the
+   * app shipped with before #95. When non-empty, audio-recorder temporarily
+   * sets this device as the system default input for the duration of the
+   * capture and restores the previous default on shutdown.
+   */
+  dictationMicrophone: string;
+  /**
    * Directory where "quick save" stores captured PNGs. Empty string → use
    * ~/Desktop.
    */
@@ -88,6 +96,7 @@ const DEFAULT_SETTINGS: MarshalSettings = {
   dictationLanguage: "auto",
   dictationAutoPaste: false,
   dictationPrompt: DEFAULT_DICTATION_PROMPT,
+  dictationMicrophone: "",
   captureDefaultFolder: "",
   launchAtLogin: false,
   checkForUpdatesAutomatic: true,
@@ -170,6 +179,11 @@ export function applySettingsToEnv(settings: MarshalSettings): void {
   process.env.MARSHAL_DICTATION_LANGUAGE = settings.dictationLanguage;
   process.env.MARSHAL_DICTATION_AUTOPASTE = settings.dictationAutoPaste ? "1" : "0";
   process.env.MARSHAL_DICTATION_PROMPT = settings.dictationPrompt;
+  if (settings.dictationMicrophone) {
+    process.env.MARSHAL_DICTATION_MIC = settings.dictationMicrophone;
+  } else {
+    delete process.env.MARSHAL_DICTATION_MIC;
+  }
   // Forwarded to the backend utility process so the local bridge server can
   // persist captures (e.g. /capture/fullpage from the Chrome extension) into
   // the same folder the rest of the capture pipeline uses.
@@ -236,6 +250,9 @@ function normalize(input: Partial<MarshalSettings>): MarshalSettings {
     dictationPrompt: typeof input.dictationPrompt === "string"
       ? input.dictationPrompt
       : DEFAULT_SETTINGS.dictationPrompt,
+    dictationMicrophone: typeof input.dictationMicrophone === "string"
+      ? input.dictationMicrophone.trim()
+      : DEFAULT_SETTINGS.dictationMicrophone,
     captureDefaultFolder: typeof input.captureDefaultFolder === "string"
       ? input.captureDefaultFolder
       : DEFAULT_SETTINGS.captureDefaultFolder,

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -121,6 +121,12 @@ if (process.platform === "darwin") {
       fallbackNote: "dictation will fall back to clipboard-only (no auto-paste)"
     },
     {
+      src: path.join(root, "desktop", "dictation", "mic-list.swift"),
+      out: path.join(root, "dist", "desktop", "dictation", "mic-list"),
+      label: "mic-list",
+      fallbackNote: "microphone selection dropdown will show 'system default' only"
+    },
+    {
       src: path.join(root, "desktop", "translator", "apple-vision-ocr.swift"),
       out: path.join(root, "dist", "desktop", "translator", "apple-vision-ocr"),
       label: "apple-vision-ocr",

--- a/tests/mic-discover.test.ts
+++ b/tests/mic-discover.test.ts
@@ -1,0 +1,142 @@
+// tests/mic-discover.test.ts
+// Unit tests for mic-discover.ts — JSON parser + spawn wrapper. The actual
+// Core Audio HAL probe is integration-tested live by mic-list.swift, not
+// here; we only assert the contract between the helper and the JSON it
+// receives so renderer-side code can rely on the shape.
+
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import { mkdtemp, writeFile, chmod, rm } from "node:fs/promises";
+
+import {
+  listMicrophones,
+  parseMicList,
+  type Microphone
+} from "../desktop/dictation/mic-discover.ts";
+
+const tmpRoot = path.join(os.tmpdir(), "marshal-mic-discover-tests");
+
+async function writeStubBin(name: string, body: string): Promise<string> {
+  const dir = await mkdtemp(`${tmpRoot}-`);
+  const target = path.join(dir, name);
+  await writeFile(target, `#!/usr/bin/env bash\n${body}\n`);
+  await chmod(target, 0o755);
+  return target;
+}
+
+const BUILTIN: Microphone = {
+  id: "BuiltInMicrophoneDevice",
+  name: "MacBook Pro Microphone",
+  isDefault: true,
+  manufacturer: "Apple Inc.",
+  transportType: "BuiltIn"
+};
+
+describe("parseMicList", () => {
+  it("parses a JSON array of valid devices", () => {
+    const stdout = JSON.stringify([BUILTIN]);
+    const result = parseMicList(stdout);
+    expect(result).toEqual([BUILTIN]);
+  });
+
+  it("returns empty list on empty stdout", () => {
+    expect(parseMicList("")).toEqual([]);
+    expect(parseMicList("   \n")).toEqual([]);
+  });
+
+  it("returns empty list on malformed JSON", () => {
+    expect(parseMicList("not json")).toEqual([]);
+    expect(parseMicList("[{ id:")).toEqual([]);
+  });
+
+  it("returns empty list when top-level is not an array", () => {
+    expect(parseMicList('{"id":"X"}')).toEqual([]);
+    expect(parseMicList('"string"')).toEqual([]);
+    expect(parseMicList("null")).toEqual([]);
+  });
+
+  it("skips entries without a valid id", () => {
+    const stdout = JSON.stringify([
+      { id: "", name: "Missing UID" },
+      { id: "valid-uid", name: "OK", isDefault: true, manufacturer: "", transportType: "USB" }
+    ]);
+    const result = parseMicList(stdout);
+    expect(result.map((m) => m.id)).toEqual(["valid-uid"]);
+  });
+
+  it("coerces missing string fields to empty strings", () => {
+    const stdout = JSON.stringify([{ id: "x", name: "Just name" }]);
+    const result = parseMicList(stdout);
+    expect(result[0]).toEqual({
+      id: "x",
+      name: "Just name",
+      isDefault: false,
+      manufacturer: "",
+      transportType: ""
+    });
+  });
+
+  it("treats non-true isDefault values as false", () => {
+    const stdout = JSON.stringify([
+      { id: "a", name: "A", isDefault: "yes" },
+      { id: "b", name: "B", isDefault: 1 },
+      { id: "c", name: "C", isDefault: true }
+    ]);
+    const result = parseMicList(stdout);
+    expect(result.find((m) => m.id === "a")?.isDefault).toBe(false);
+    expect(result.find((m) => m.id === "b")?.isDefault).toBe(false);
+    expect(result.find((m) => m.id === "c")?.isDefault).toBe(true);
+  });
+
+  it("falls back to the id for the display name when name is missing/empty", () => {
+    const stdout = JSON.stringify([{ id: "weird-uid", name: "" }]);
+    const result = parseMicList(stdout);
+    expect(result[0].name).toBe("weird-uid");
+  });
+});
+
+describe("listMicrophones", () => {
+  it("returns parsed devices when the helper exits cleanly", async () => {
+    const bin = await writeStubBin(
+      "mic-list-ok",
+      `echo '${JSON.stringify([BUILTIN])}'`
+    );
+    try {
+      const result = await listMicrophones({ binPath: bin });
+      expect(result).toEqual([BUILTIN]);
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+
+  it("resolves to empty list if the binary is missing", async () => {
+    const result = await listMicrophones({
+      binPath: "/nonexistent/path/mic-list-does-not-exist"
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("times out gracefully on a hung helper", async () => {
+    const bin = await writeStubBin("mic-list-hang", "sleep 5");
+    try {
+      const start = Date.now();
+      const result = await listMicrophones({ binPath: bin, timeoutMs: 100 });
+      const elapsed = Date.now() - start;
+      expect(result).toEqual([]);
+      expect(elapsed).toBeLessThan(2_000);
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty on malformed helper output", async () => {
+    const bin = await writeStubBin("mic-list-garbage", 'echo "not json at all"');
+    try {
+      const result = await listMicrophones({ binPath: bin });
+      expect(result).toEqual([]);
+    } finally {
+      await rm(path.dirname(bin), { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/settings-store.test.ts
+++ b/tests/settings-store.test.ts
@@ -99,6 +99,7 @@ describe("saveSettings", () => {
       dictationLanguage: "uk",
       dictationAutoPaste: true,
       dictationPrompt: "React, Magento, PR",
+      dictationMicrophone: "",
       captureDefaultFolder: "",
       launchAtLogin: false,
       checkForUpdatesAutomatic: true,


### PR DESCRIPTION
## Summary

Settings panel now has a **Microphone** dropdown. Pick which input device dictation records from — no more bouncing to System Settings → Sound → Input every time AirPods reconnect.

## How it works

1. **`desktop/dictation/mic-list.swift`** — new Core Audio HAL helper that enumerates input devices (`kAudioHardwarePropertyDevices` → filter to ones with streams in input scope) and prints a JSON array sorted with the system default first. Read-only, no TCC impact.

2. **`desktop/dictation/audio-recorder.swift`** — extended with optional `--device <uniqueID>`:
   - reads current default input via `AudioObjectGetPropertyData`
   - swaps to the chosen device with `AudioObjectSetPropertyData`
   - records (existing AVAudioRecorder path, unchanged)
   - restores the previous default in the SIGTERM/SIGINT handler

   Race window: another app starting audio capture during our recording would also see the swapped default. macOS input is almost always single-tenant in practice, and the restore handler covers normal exit paths.

3. **`desktop/dictation/mic-discover.ts`** — TS spawn wrapper around `mic-list`. 1.5 s timeout, fail-safe to empty list (never throws). Parser is defensive: missing fields → safe defaults; non-array root → empty list.

4. **Settings UI** — new "Microphone" select. First option `System default (track macOS Sound > Input)` keeps the existing behavior (value = `""`). "Refresh list" link re-polls after plugging in a new mic.

5. **IPC**: `marshal:dictation-list-mics` returns `{ ok, devices, error? }`. Exposed on preload as `api.listMicrophones()`.

6. **Settings persistence**: `MarshalSettings.dictationMicrophone: string` round-trips via existing save/load infrastructure. `MARSHAL_DICTATION_MIC` env var is applied by `applySettingsToEnv` and consumed by `dictation-service.ts` when spawning the recorder.

## Verification

- `npm run check` → 262 tests pass (was 250 — added 12 mic-discover cases)
- `dist/desktop/dictation/mic-list` direct call on the dev box returns:
  ```json
  [
    {"id":"BuiltInMicrophoneDevice","name":"Мікрофон MacBook Pro","isDefault":true,"manufacturer":"Apple Inc.","transportType":"BuiltIn"},
    {"id":"16C18E3A-...","name":"Мікрофон (iPhone Hank)","isDefault":false,"manufacturer":"Apple Inc.","transportType":"ContinuityWireless"}
  ]
  ```
- Codesigned with `Marshal Self-Signed` (#88 stable identity).
- audio-recorder compiles with new flag; no-arg invocation still works (back-compat).

## Test plan

- [ ] Open settings → see Microphone dropdown with all your input devices + the system default flagged
- [ ] Pick a non-default mic → save → Cmd+Alt+M → recording uses chosen mic regardless of macOS default
- [ ] Switch back to "System default" → recording uses macOS default again (no HAL swap at all)
- [ ] Unplug the chosen mic → "Refresh list" updates the dropdown; saved value falls back to system default automatically (browser select.value fallback)
- [ ] Kill Marshal mid-recording with SIGKILL (process monitor) → confirm next launch sees previous default in System Settings (the SIGKILL path can't restore, that's expected)
- [ ] Existing 250 tests still green

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)