### PR TITLE
[codex] Surface launch-at-login failures

### DIFF
--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -148,9 +148,9 @@ async function bootstrap(): Promise<void> {
 
     // Settings override .env values. Must be applied BEFORE the backend utility
     // process forks so the child inherits the correct env.
-    const initialSettings = loadSettings();
+    let initialSettings = loadSettings();
     applySettingsToEnv(initialSettings);
-    applyLaunchAtLogin(initialSettings);
+    initialSettings = applyLaunchAtLogin(initialSettings);
 
     registerIpcHandlers();
     createMenubarAndWindow();
@@ -295,9 +295,9 @@ function registerIpcHandlers(): void {
     return { ok: true };
   });
   handleIpc("marshal:update-settings", async (_event, next: Partial<MarshalSettings>) => {
-    const saved = saveSettings(next ?? {});
+    let saved = saveSettings(next ?? {});
     applySettingsToEnv(saved);
-    applyLaunchAtLogin(saved);
+    saved = applyLaunchAtLogin(saved);
     restartDictation();
     // Hot-swap the translator so the new choice takes effect without waiting
     // for a full app restart. Apply bridge FIRST so "auto" resolves against
@@ -1504,15 +1504,41 @@ function buildTrayMenu(): Electron.Menu {
  * supported only on macOS/Windows and we deliberately scope packaging to
  * macOS today.
  */
-function applyLaunchAtLogin(settings: MarshalSettings): void {
-  if (process.platform !== "darwin" && process.platform !== "win32") return;
-  app.setLoginItemSettings({
-    openAtLogin: settings.launchAtLogin,
-    // openAsHidden hides the dock-less accessory app on launch — we already
-    // suppress the dock via setActivationPolicy("accessory"), but this also
-    // suppresses any brief renderer flash.
-    openAsHidden: true
-  });
+function applyLaunchAtLogin(settings: MarshalSettings): MarshalSettings {
+  if (process.platform !== "darwin" && process.platform !== "win32") return settings;
+
+  const requested = settings.launchAtLogin;
+  try {
+    app.setLoginItemSettings({
+      openAtLogin: requested,
+      // openAsHidden hides the dock-less accessory app on launch — we already
+      // suppress the dock via setActivationPolicy("accessory"), but this also
+      // suppresses any brief renderer flash.
+      openAsHidden: true
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn("[marshal] launch-at-login update failed:", message);
+    return saveSettings({
+      launchAtLogin: false,
+      launchAtLoginLastError: message
+    });
+  }
+
+  const actual = app.getLoginItemSettings().openAtLogin;
+  if (requested && !actual) {
+    const message = "macOS rejected the Login Item update. Check System Settings -> General -> Login Items.";
+    console.warn("[marshal] launch-at-login update rejected:", message);
+    return saveSettings({
+      launchAtLogin: false,
+      launchAtLoginLastError: message
+    });
+  }
+
+  if (settings.launchAtLoginLastError) {
+    return saveSettings({ launchAtLoginLastError: "" });
+  }
+  return settings;
 }
 
 async function getSetupHealth(): Promise<SetupHealthSummary> {
@@ -1529,7 +1555,12 @@ async function getSetupHealth(): Promise<SetupHealthSummary> {
     apiKeyPresent: Boolean(process.env.MARSHAL_API_KEY?.trim()),
     whisperBinPath: whisper.bin,
     whisperModelPath: whisper.model,
-    codesignIdentityPresent: isDarwin ? await hasMarshalCodesignIdentity() : undefined
+    codesignIdentityPresent: isDarwin ? await hasMarshalCodesignIdentity() : undefined,
+    launchAtLogin: settings.launchAtLogin,
+    launchAtLoginOpenAtLogin: process.platform === "darwin" || process.platform === "win32"
+      ? app.getLoginItemSettings().openAtLogin
+      : undefined,
+    launchAtLoginLastError: settings.launchAtLoginLastError
   });
 }
 

--- a/desktop/preload.cts
+++ b/desktop/preload.cts
@@ -120,6 +120,7 @@ const desktopApi = {
     dictationToggleTapCount?: number;
     dictationPrompt?: string;
     dictationMicrophone?: string;
+    launchAtLoginLastError?: string;
   }) => ipcRenderer.invoke("marshal:update-settings", settings),
   getDictationDefaults: () => ipcRenderer.invoke("marshal:get-dictation-defaults") as Promise<{ prompt: string }>,
   listMicrophones: () => ipcRenderer.invoke("marshal:dictation-list-mics") as Promise<{

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -1096,9 +1096,21 @@ async function saveSettingsFromForm() {
   dom.settingsSave.disabled = true;
   showSettingsStatus("Saving and restarting backend…", null);
   try {
-    await api.updateSettings(payload);
-    showSettingsStatus("Saved. New settings are active.", "success");
-    setTimeout(closeSettings, 900);
+    const saved = await api.updateSettings(payload);
+    if (dom.settingsLaunchAtLogin) {
+      dom.settingsLaunchAtLogin.checked = saved?.launchAtLogin ?? false;
+    }
+    void refreshSetupHealth();
+    const launchRejected = payload.launchAtLogin && saved?.launchAtLogin === false;
+    showSettingsStatus(
+      launchRejected
+        ? "Saved, but macOS rejected Start at Login. See Setup Health."
+        : "Saved. New settings are active.",
+      launchRejected ? "error" : "success"
+    );
+    if (!launchRejected) {
+      setTimeout(closeSettings, 900);
+    }
   } catch (err) {
     console.error("saveSettings failed", err);
     showSettingsStatus(`Failed: ${err?.message ?? err}`, "error");

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -289,6 +289,7 @@
               <label for="settings-launch-at-login">Start Marshal at login</label>
               <p class="field-hint">
                 Registers Marshal as a macOS Login Item. Toggling here matches the same option in the tray menu.
+                If macOS rejects the change, this checkbox returns to off and Setup Health shows the reason.
               </p>
             </div>
           </fieldset>

--- a/desktop/settings-store.ts
+++ b/desktop/settings-store.ts
@@ -80,6 +80,13 @@ export type MarshalSettings = {
    */
   launchAtLogin: boolean;
   /**
+   * Last macOS/Windows Login Item reconciliation failure. Empty string means
+   * the persisted preference matches what the OS reports, or the feature is
+   * disabled. Kept in settings so Setup Health can surface failures discovered
+   * during startup before the Settings modal is opened.
+   */
+  launchAtLoginLastError: string;
+  /**
    * Check the GitHub Releases API on a schedule and surface new versions as
    * a tray notification. Disabling this only stops the silent background
    * check; the manual "Check for updates…" tray entry still works.
@@ -116,6 +123,7 @@ const DEFAULT_SETTINGS: MarshalSettings = {
   dictationMicrophone: "",
   captureDefaultFolder: "",
   launchAtLogin: false,
+  launchAtLoginLastError: "",
   checkForUpdatesAutomatic: true,
   lastDismissedVersion: ""
 };
@@ -288,6 +296,9 @@ function normalize(input: Partial<MarshalSettings>): MarshalSettings {
     launchAtLogin: typeof input.launchAtLogin === "boolean"
       ? input.launchAtLogin
       : DEFAULT_SETTINGS.launchAtLogin,
+    launchAtLoginLastError: typeof input.launchAtLoginLastError === "string"
+      ? input.launchAtLoginLastError.trim()
+      : DEFAULT_SETTINGS.launchAtLoginLastError,
     checkForUpdatesAutomatic: typeof input.checkForUpdatesAutomatic === "boolean"
       ? input.checkForUpdatesAutomatic
       : DEFAULT_SETTINGS.checkForUpdatesAutomatic,

--- a/desktop/setup-health.ts
+++ b/desktop/setup-health.ts
@@ -24,6 +24,9 @@ export type SetupHealthInput = {
   whisperBinPath: string;
   whisperModelPath: string;
   codesignIdentityPresent?: boolean;
+  launchAtLogin: boolean;
+  launchAtLoginOpenAtLogin?: boolean;
+  launchAtLoginLastError?: string;
   exists?: (path: string) => boolean;
 };
 
@@ -110,9 +113,51 @@ export function buildSetupHealth(input: SetupHealthInput): SetupHealthSummary {
       : undefined
   });
 
+  items.push(launchAtLoginItem(input));
+
   return {
     items,
     counts: countStatuses(items)
+  };
+}
+
+function launchAtLoginItem(input: SetupHealthInput): SetupHealthItem {
+  if (input.platform !== "darwin" && input.platform !== "win32") {
+    return {
+      id: "launch-at-login",
+      label: "Start at Login",
+      status: "unknown",
+      detail: "Only checked on macOS and Windows."
+    };
+  }
+
+  const lastError = (input.launchAtLoginLastError ?? "").trim();
+  if (!input.launchAtLogin) {
+    return {
+      id: "launch-at-login",
+      label: "Start at Login",
+      status: lastError ? "warn" : "ok",
+      detail: lastError
+        ? `Disabled because the OS rejected the last Login Item update: ${lastError}`
+        : "Disabled by preference."
+    };
+  }
+
+  if (input.launchAtLoginOpenAtLogin) {
+    return {
+      id: "launch-at-login",
+      label: "Start at Login",
+      status: "ok",
+      detail: "Enabled. The OS reports Marshal as a Login Item."
+    };
+  }
+
+  return {
+    id: "launch-at-login",
+    label: "Start at Login",
+    status: "warn",
+    detail: lastError || "Requested, but the OS does not report Marshal as a Login Item.",
+    action: input.platform === "darwin" ? "System Settings -> General -> Login Items" : undefined
   };
 }
 

--- a/tests/settings-store.test.ts
+++ b/tests/settings-store.test.ts
@@ -108,6 +108,7 @@ describe("saveSettings", () => {
       dictationMicrophone: "",
       captureDefaultFolder: "",
       launchAtLogin: false,
+      launchAtLoginLastError: "",
       checkForUpdatesAutomatic: true,
       lastDismissedVersion: ""
     });
@@ -135,6 +136,11 @@ describe("saveSettings", () => {
   it("round-trips launchAtLogin true", () => {
     saveSettings({ launchAtLogin: true });
     expect(loadSettings().launchAtLogin).toBe(true);
+  });
+
+  it("round-trips launchAtLoginLastError", () => {
+    saveSettings({ launchAtLoginLastError: "Operation not permitted" });
+    expect(loadSettings().launchAtLoginLastError).toBe("Operation not permitted");
   });
 
   it("falls back to default launchAtLogin for non-boolean values", () => {

--- a/tests/setup-health.test.ts
+++ b/tests/setup-health.test.ts
@@ -19,6 +19,8 @@ describe("buildSetupHealth", () => {
       whisperBinPath: "/whisper-cli",
       whisperModelPath: "/model.bin",
       codesignIdentityPresent: true,
+      launchAtLogin: false,
+      launchAtLoginOpenAtLogin: false,
       exists: () => true
     });
 
@@ -30,7 +32,8 @@ describe("buildSetupHealth", () => {
       "screen-recording": "ok",
       "whisper-local": "ok",
       "cloud-api": "ok",
-      codesign: "ok"
+      codesign: "ok",
+      "launch-at-login": "ok"
     });
   });
 
@@ -46,6 +49,8 @@ describe("buildSetupHealth", () => {
       whisperBinPath: "/missing-bin",
       whisperModelPath: "/missing-model",
       codesignIdentityPresent: true,
+      launchAtLogin: false,
+      launchAtLoginOpenAtLogin: false,
       exists: () => false
     });
 
@@ -65,6 +70,8 @@ describe("buildSetupHealth", () => {
       whisperBinPath: "/whisper-cli",
       whisperModelPath: "/model.bin",
       codesignIdentityPresent: true,
+      launchAtLogin: false,
+      launchAtLoginOpenAtLogin: false,
       exists: () => true
     });
     const local = buildSetupHealth({
@@ -78,6 +85,8 @@ describe("buildSetupHealth", () => {
       whisperBinPath: "/whisper-cli",
       whisperModelPath: "/model.bin",
       codesignIdentityPresent: true,
+      launchAtLogin: false,
+      launchAtLoginOpenAtLogin: false,
       exists: () => true
     });
 
@@ -97,6 +106,8 @@ describe("buildSetupHealth", () => {
       whisperBinPath: "/whisper-cli",
       whisperModelPath: "/model.bin",
       codesignIdentityPresent: false,
+      launchAtLogin: false,
+      launchAtLoginOpenAtLogin: false,
       exists: () => true
     });
 
@@ -121,6 +132,8 @@ describe("buildSetupHealth", () => {
       whisperBinPath: "/missing-bin",
       whisperModelPath: "/missing-model",
       codesignIdentityPresent: true,
+      launchAtLogin: false,
+      launchAtLoginOpenAtLogin: false,
       exists: () => false
     });
 
@@ -131,5 +144,49 @@ describe("buildSetupHealth", () => {
       "screen-recording": "ok"
     });
     expect(summary.counts.error).toBe(0);
+  });
+
+  it("warns when launch-at-login was requested but the OS rejected it", () => {
+    const summary = buildSetupHealth({
+      platform: "darwin",
+      dictationEnabled: true,
+      dictationBackend: "hybrid",
+      microphoneStatus: "granted",
+      screenStatus: "granted",
+      accessibilityTrusted: true,
+      apiKeyPresent: true,
+      whisperBinPath: "/whisper-cli",
+      whisperModelPath: "/model.bin",
+      codesignIdentityPresent: true,
+      launchAtLogin: true,
+      launchAtLoginOpenAtLogin: false,
+      launchAtLoginLastError: "Operation not permitted",
+      exists: () => true
+    });
+
+    const item = summary.items.find((entry) => entry.id === "launch-at-login");
+    expect(item?.status).toBe("warn");
+    expect(item?.detail).toContain("Operation not permitted");
+  });
+
+  it("marks launch-at-login ready when the OS reports it enabled", () => {
+    const summary = buildSetupHealth({
+      platform: "darwin",
+      dictationEnabled: true,
+      dictationBackend: "hybrid",
+      microphoneStatus: "granted",
+      screenStatus: "granted",
+      accessibilityTrusted: true,
+      apiKeyPresent: true,
+      whisperBinPath: "/whisper-cli",
+      whisperModelPath: "/model.bin",
+      codesignIdentityPresent: true,
+      launchAtLogin: true,
+      launchAtLoginOpenAtLogin: true,
+      exists: () => true
+    });
+
+    expect(ids(summary)["launch-at-login"]).toBe("ok");
+    expect(summary.counts.warn).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- reconcile `launchAtLogin` against the OS-reported Login Item state after every update
- persist `launchAtLoginLastError` and reset the preference to off when macOS rejects the Login Item change
- surface the failure in Setup Health and keep the Settings checkbox honest after save

## Validation

- `npm run check`
- `npm run build`

Closes #121
