### PR TITLE
[codex] Prompt for permissions after updates

### DIFF
--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -29,6 +29,7 @@ import { listMicrophones } from "./dictation/mic-discover.ts";
 import { DEFAULT_DICTATION_PROMPT, resolveWhisperAssetPaths } from "./dictation/whisper-backend.ts";
 import { MeetingIndicator } from "./meeting/meeting-indicator.ts";
 import { MeetingRecorder } from "./meeting/meeting-recorder.ts";
+import { runPostInstallPermissionCheck } from "./permissions/post-install-check.ts";
 import { applySettingsToEnv, loadSettings, saveSettings, type MarshalSettings } from "./settings-store.ts";
 import { buildSetupHealth, type SetupHealthSummary } from "./setup-health.ts";
 import { ClipboardMonitor } from "./translator/clipboard-monitor.ts";
@@ -158,6 +159,27 @@ async function bootstrap(): Promise<void> {
     // surface fully testable.
     if (process.env.MARSHAL_HEADLESS !== "1") {
       logPermissionStatus();
+      void runPostInstallPermissionCheck({
+        currentVersion: app.getVersion(),
+        loadSettings,
+        saveSettings,
+        queryPermissions: () => ({
+          platform: process.platform,
+          microphoneStatus: process.platform === "darwin"
+            ? systemPreferences.getMediaAccessStatus("microphone")
+            : "granted",
+          screenStatus: process.platform === "darwin"
+            ? systemPreferences.getMediaAccessStatus("screen")
+            : "granted",
+          accessibilityTrusted: process.platform === "darwin"
+            ? systemPreferences.isTrustedAccessibilityClient(false)
+            : true
+        }),
+        showMessageBox: (options) => dialog.showMessageBox(options),
+        openExternal: (url) => shell.openExternal(url)
+      }).catch((err) => {
+        console.warn("[marshal] post-install permission check failed:", err);
+      });
       initTranslator();
       initCapture();
       initDictation();

--- a/desktop/permissions/post-install-check.ts
+++ b/desktop/permissions/post-install-check.ts
@@ -1,0 +1,172 @@
+import type { MarshalSettings } from "../settings-store.ts";
+
+type MediaAccessStatus = "not-determined" | "granted" | "denied" | "restricted" | "unknown";
+
+export type PermissionCheckSnapshot = {
+  platform: NodeJS.Platform;
+  currentVersion: string;
+  lastSeenVersion: string;
+  microphoneStatus: MediaAccessStatus;
+  screenStatus: MediaAccessStatus;
+  accessibilityTrusted: boolean;
+};
+
+export type MissingPermissionId = "microphone" | "accessibility" | "screen-recording";
+
+export type MissingPermission = {
+  id: MissingPermissionId;
+  label: string;
+  status: string;
+  action: string;
+  url: string;
+};
+
+export type PermissionCheckDecision = {
+  shouldPrompt: boolean;
+  missing: MissingPermission[];
+};
+
+export type PostInstallPermissionCheckDeps = {
+  currentVersion: string;
+  loadSettings: () => MarshalSettings;
+  saveSettings: (settings: Partial<MarshalSettings>) => MarshalSettings;
+  queryPermissions: () => Omit<PermissionCheckSnapshot, "currentVersion" | "lastSeenVersion">;
+  showMessageBox: (options: {
+    type: "info";
+    title: string;
+    message: string;
+    detail?: string;
+    buttons: string[];
+    defaultId?: number;
+    cancelId?: number;
+  }) => Promise<{ response: number }>;
+  openExternal: (url: string) => Promise<unknown>;
+};
+
+const PERMISSION_DEFS: Record<MissingPermissionId, Omit<MissingPermission, "status">> = {
+  microphone: {
+    id: "microphone",
+    label: "Microphone",
+    action: "System Settings -> Privacy & Security -> Microphone",
+    url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+  },
+  accessibility: {
+    id: "accessibility",
+    label: "Accessibility",
+    action: "System Settings -> Privacy & Security -> Accessibility",
+    url: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+  },
+  "screen-recording": {
+    id: "screen-recording",
+    label: "Screen Recording",
+    action: "System Settings -> Privacy & Security -> Screen Recording",
+    url: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+  }
+};
+
+export function evaluatePostInstallPermissionCheck(
+  snapshot: PermissionCheckSnapshot
+): PermissionCheckDecision {
+  if (snapshot.platform !== "darwin") {
+    return { shouldPrompt: false, missing: [] };
+  }
+  if (!snapshot.currentVersion || snapshot.currentVersion === snapshot.lastSeenVersion) {
+    return { shouldPrompt: false, missing: [] };
+  }
+
+  const missing: MissingPermission[] = [];
+  if (snapshot.microphoneStatus !== "granted") {
+    missing.push({ ...PERMISSION_DEFS.microphone, status: snapshot.microphoneStatus });
+  }
+  if (!snapshot.accessibilityTrusted) {
+    missing.push({ ...PERMISSION_DEFS.accessibility, status: "denied" });
+  }
+  if (snapshot.screenStatus !== "granted") {
+    missing.push({ ...PERMISSION_DEFS["screen-recording"], status: snapshot.screenStatus });
+  }
+
+  return { shouldPrompt: missing.length > 0, missing };
+}
+
+export async function runPostInstallPermissionCheck(
+  deps: PostInstallPermissionCheckDeps
+): Promise<void> {
+  const settings = deps.loadSettings();
+  const decision = evaluatePostInstallPermissionCheck({
+    ...deps.queryPermissions(),
+    currentVersion: deps.currentVersion,
+    lastSeenVersion: settings.lastSeenVersion
+  });
+
+  if (!decision.shouldPrompt) {
+    if (settings.lastSeenVersion !== deps.currentVersion) {
+      deps.saveSettings({ lastSeenVersion: deps.currentVersion });
+    }
+    return;
+  }
+
+  let missing = decision.missing;
+  while (true) {
+    const buttons = [
+      ...missing.map((permission) => `Open ${permission.label}`),
+      "Re-test",
+      "Later"
+    ];
+    const retestIndex = missing.length;
+    const laterIndex = missing.length + 1;
+
+    const { response } = await deps.showMessageBox({
+      type: "info",
+      title: "Marshal permissions may need attention",
+      message:
+        "Marshal was updated or rebuilt. macOS may require privacy permissions again " +
+        "before dictation, push-to-talk, and capture work correctly.",
+      detail: buildPermissionDetail(missing),
+      buttons,
+      defaultId: 0,
+      cancelId: laterIndex
+    });
+
+    if (response >= 0 && response < missing.length) {
+      await deps.openExternal(missing[response].url);
+      deps.saveSettings({ lastSeenVersion: deps.currentVersion });
+      return;
+    }
+
+    if (response === retestIndex) {
+      const next = evaluatePostInstallPermissionCheck({
+        ...deps.queryPermissions(),
+        currentVersion: deps.currentVersion,
+        lastSeenVersion: ""
+      });
+      if (!next.shouldPrompt) {
+        await deps.showMessageBox({
+          type: "info",
+          title: "Marshal permissions are ready",
+          message: "Microphone, Accessibility, and Screen Recording permissions look ready.",
+          buttons: ["OK"],
+          defaultId: 0,
+          cancelId: 0
+        });
+        deps.saveSettings({ lastSeenVersion: deps.currentVersion });
+        return;
+      }
+      missing = next.missing;
+      continue;
+    }
+
+    deps.saveSettings({ lastSeenVersion: deps.currentVersion });
+    return;
+  }
+}
+
+function buildPermissionDetail(missing: MissingPermission[]): string {
+  const lines = missing.map((permission) =>
+    `- ${permission.label}: ${permission.status}. Open ${permission.action}.`
+  );
+  lines.push(
+    "",
+    "Input Monitoring has no Electron status API. If push-to-talk still does not react after Accessibility is granted, also check System Settings -> Privacy & Security -> Input Monitoring."
+  );
+  return lines.join("\n");
+}

--- a/desktop/settings-store.ts
+++ b/desktop/settings-store.ts
@@ -98,6 +98,12 @@ export type MarshalSettings = {
    * subsequent newer release so the user sees the next one.
    */
   lastDismissedVersion: string;
+  /**
+   * App version whose post-update permission check has already been surfaced.
+   * Self-signed macOS builds can lose TCC grants after replacement; this
+   * keeps the warning one-shot per app version instead of nagging forever.
+   */
+  lastSeenVersion: string;
 };
 
 const DEFAULT_SETTINGS: MarshalSettings = {
@@ -125,7 +131,8 @@ const DEFAULT_SETTINGS: MarshalSettings = {
   launchAtLogin: false,
   launchAtLoginLastError: "",
   checkForUpdatesAutomatic: true,
-  lastDismissedVersion: ""
+  lastDismissedVersion: "",
+  lastSeenVersion: ""
 };
 
 const VALID_DICTATION_BACKENDS: readonly DictationBackend[] = ["whisper-cpp", "groq", "hybrid"];
@@ -304,7 +311,10 @@ function normalize(input: Partial<MarshalSettings>): MarshalSettings {
       : DEFAULT_SETTINGS.checkForUpdatesAutomatic,
     lastDismissedVersion: typeof input.lastDismissedVersion === "string"
       ? input.lastDismissedVersion
-      : DEFAULT_SETTINGS.lastDismissedVersion
+      : DEFAULT_SETTINGS.lastDismissedVersion,
+    lastSeenVersion: typeof input.lastSeenVersion === "string"
+      ? input.lastSeenVersion
+      : DEFAULT_SETTINGS.lastSeenVersion
   };
 }
 

--- a/tests/post-install-check.test.ts
+++ b/tests/post-install-check.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  evaluatePostInstallPermissionCheck,
+  runPostInstallPermissionCheck,
+  type PermissionCheckSnapshot
+} from "../desktop/permissions/post-install-check.ts";
+import type { MarshalSettings } from "../desktop/settings-store.ts";
+
+const baseSnapshot: PermissionCheckSnapshot = {
+  platform: "darwin",
+  currentVersion: "0.2.0",
+  lastSeenVersion: "0.1.9",
+  microphoneStatus: "granted",
+  screenStatus: "granted",
+  accessibilityTrusted: true
+};
+
+function settings(overrides: Partial<MarshalSettings> = {}): MarshalSettings {
+  return {
+    bridgeMode: "claude-cli",
+    claudeModel: "sonnet",
+    codexModel: "",
+    translatorBackend: "auto",
+    appearance: "system",
+    dictationEnabled: true,
+    dictationHotkey: "RightCmd",
+    dictationBackend: "hybrid",
+    dictationLanguage: "auto",
+    dictationAutoPaste: false,
+    dictationHoldDelayMs: 0,
+    dictationToggleTapCount: 0,
+    dictationPrompt: "",
+    dictationMicrophone: "",
+    captureDefaultFolder: "",
+    launchAtLogin: false,
+    launchAtLoginLastError: "",
+    checkForUpdatesAutomatic: true,
+    lastDismissedVersion: "",
+    lastSeenVersion: "",
+    ...overrides
+  };
+}
+
+describe("evaluatePostInstallPermissionCheck", () => {
+  it("does not prompt off macOS", () => {
+    const decision = evaluatePostInstallPermissionCheck({
+      ...baseSnapshot,
+      platform: "linux",
+      microphoneStatus: "denied",
+      screenStatus: "denied",
+      accessibilityTrusted: false
+    });
+    expect(decision.shouldPrompt).toBe(false);
+    expect(decision.missing).toEqual([]);
+  });
+
+  it("does not prompt twice for the same version", () => {
+    const decision = evaluatePostInstallPermissionCheck({
+      ...baseSnapshot,
+      lastSeenVersion: "0.2.0",
+      microphoneStatus: "denied"
+    });
+    expect(decision.shouldPrompt).toBe(false);
+  });
+
+  it("collects missing macOS permission gates after a version change", () => {
+    const decision = evaluatePostInstallPermissionCheck({
+      ...baseSnapshot,
+      microphoneStatus: "denied",
+      screenStatus: "not-determined",
+      accessibilityTrusted: false
+    });
+    expect(decision.shouldPrompt).toBe(true);
+    expect(decision.missing.map((item) => item.id)).toEqual([
+      "microphone",
+      "accessibility",
+      "screen-recording"
+    ]);
+  });
+});
+
+describe("runPostInstallPermissionCheck", () => {
+  it("marks a new version seen when permissions are already ready", async () => {
+    const saveSettings = vi.fn((next: Partial<MarshalSettings>) => settings(next));
+    const showMessageBox = vi.fn();
+
+    await runPostInstallPermissionCheck({
+      currentVersion: "0.2.0",
+      loadSettings: () => settings({ lastSeenVersion: "0.1.9" }),
+      saveSettings,
+      queryPermissions: () => ({
+        platform: "darwin",
+        microphoneStatus: "granted",
+        screenStatus: "granted",
+        accessibilityTrusted: true
+      }),
+      showMessageBox,
+      openExternal: vi.fn()
+    });
+
+    expect(showMessageBox).not.toHaveBeenCalled();
+    expect(saveSettings).toHaveBeenCalledWith({ lastSeenVersion: "0.2.0" });
+  });
+
+  it("opens the selected privacy pane and records the version", async () => {
+    const saveSettings = vi.fn((next: Partial<MarshalSettings>) => settings(next));
+    const openExternal = vi.fn(async () => undefined);
+
+    await runPostInstallPermissionCheck({
+      currentVersion: "0.2.0",
+      loadSettings: () => settings({ lastSeenVersion: "0.1.9" }),
+      saveSettings,
+      queryPermissions: () => ({
+        platform: "darwin",
+        microphoneStatus: "denied",
+        screenStatus: "granted",
+        accessibilityTrusted: true
+      }),
+      showMessageBox: vi.fn(async () => ({ response: 0 })),
+      openExternal
+    });
+
+    expect(openExternal).toHaveBeenCalledWith(
+      "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+    );
+    expect(saveSettings).toHaveBeenCalledWith({ lastSeenVersion: "0.2.0" });
+  });
+
+  it("re-tests and shows success when permissions become ready", async () => {
+    const saveSettings = vi.fn((next: Partial<MarshalSettings>) => settings(next));
+    const showMessageBox = vi
+      .fn()
+      .mockResolvedValueOnce({ response: 1 })
+      .mockResolvedValueOnce({ response: 0 });
+    let ready = false;
+
+    await runPostInstallPermissionCheck({
+      currentVersion: "0.2.0",
+      loadSettings: () => settings({ lastSeenVersion: "0.1.9" }),
+      saveSettings,
+      queryPermissions: () => {
+        if (ready) {
+          return {
+            platform: "darwin",
+            microphoneStatus: "granted",
+            screenStatus: "granted",
+            accessibilityTrusted: true
+          };
+        }
+        ready = true;
+        return {
+          platform: "darwin",
+          microphoneStatus: "denied",
+          screenStatus: "granted",
+          accessibilityTrusted: true
+        };
+      },
+      showMessageBox,
+      openExternal: vi.fn()
+    });
+
+    expect(showMessageBox).toHaveBeenCalledTimes(2);
+    expect(showMessageBox.mock.calls[1]?.[0].title).toBe("Marshal permissions are ready");
+    expect(saveSettings).toHaveBeenCalledWith({ lastSeenVersion: "0.2.0" });
+  });
+});

--- a/tests/settings-store.test.ts
+++ b/tests/settings-store.test.ts
@@ -110,17 +110,20 @@ describe("saveSettings", () => {
       launchAtLogin: false,
       launchAtLoginLastError: "",
       checkForUpdatesAutomatic: true,
-      lastDismissedVersion: ""
+      lastDismissedVersion: "",
+      lastSeenVersion: ""
     });
   });
 
-  it("round-trips checkForUpdatesAutomatic and lastDismissedVersion", () => {
+  it("round-trips checkForUpdatesAutomatic and version markers", () => {
     const saved = saveSettings({
       checkForUpdatesAutomatic: false,
-      lastDismissedVersion: "0.2.0"
+      lastDismissedVersion: "0.2.0",
+      lastSeenVersion: "0.1.9"
     });
     expect(saved.checkForUpdatesAutomatic).toBe(false);
     expect(saved.lastDismissedVersion).toBe("0.2.0");
+    expect(saved.lastSeenVersion).toBe("0.1.9");
   });
 
   it("falls back to default checkForUpdatesAutomatic for non-boolean values", () => {


### PR DESCRIPTION
Closes #84

## Summary
- add a post-update permission check that runs once per app version on macOS
- persist `lastSeenVersion` in settings so users are not nagged repeatedly for the same build
- show a permission recovery dialog when Microphone, Accessibility, or Screen Recording are missing after an update/rebuild
- add direct buttons for each relevant Privacy pane plus a Re-test path that confirms success after permissions are restored
- keep the check out of `MARSHAL_HEADLESS=1` so CI smoke stays non-interactive

## Validation
- `npm run typecheck`
- `npm test -- post-install-check settings-store`
- `npm run check`
- `npm run build`
- `MARSHAL_HEADLESS=1 ./node_modules/.bin/electron dist/desktop/main.js`
- `npm audit --audit-level=moderate`
